### PR TITLE
Correctly display preview of posts being edited.

### DIFF
--- a/client/hover.js
+++ b/client/hover.js
@@ -35,7 +35,7 @@ function preview_miru(event, num) {
 
 			if (post.is('section'))
 				bits = bits.slice(0, 3);
-			preview = $('<article class="preview"/>').append(
+			preview = $('<div class="preview"/>').append(
 					bits.clone());
 			if((/^editing/).test(post[0].className))	//check if the post is being edited
 				preview[0].classList.add("editing");

--- a/www/css/archive.css
+++ b/www/css/archive.css
@@ -14,7 +14,7 @@ article.highlight {
 	border-color: #bbb;
 }
 /* shouldn't happen */
-article.editing {
+.editing {
 	background-color: #fa6;
 	border-color: #e95;
 }

--- a/www/css/ashita.css
+++ b/www/css/ashita.css
@@ -4,7 +4,7 @@ a, blockquote a:hover, b.moderator {
 .bfloat > svg {
 	fill: #81a2be;
 }
-a:hover, blockquote a, .email b:hover, article.editing a:hover {
+a:hover, blockquote a, .email b:hover, .editing a:hover {
 	color: #5f89ac;
 }
 article, aside, .modal, .bmodal, .pagination, #FAQ {
@@ -15,22 +15,22 @@ article.highlight, .preview, .popup-menu {
 	background-color: #1d1d21;
 	border-color: #111;
 }
-article.editing {
-	background-color: #cec952;
-	border-color: #aa3;
-	color: black;
+.editing {
+	background-color: #cec952 !important;
+	border-color: #aa3 !important;
+	color: black !important;
 }
-article.editing a, article.editing header {
-	color: #222;
+.editing a, .editing header {
+	color: #222 !important;
 }
-article.editing em {
-	color: #656d28;
+.editing em {
+	color: #656d28 !important;
 }
-article.editing li {
-	color: #ddd;
+.editing li {
+	color: #ddd !important;
 }
-article.editing .themed {
-	color: #333;
+.editing .themed {
+	color: #333 !important;
 }
 b.admin {
 	color: #f00000;

--- a/www/css/console.css
+++ b/www/css/console.css
@@ -17,11 +17,11 @@ article form {
 article.highlight {
 	background-color: #222;
 }
-article.editing {
-	background-color: #0000b2;
+.editing {
+	background-color: #0000b2 !important;
 }
-article.editing header {
-	color: white;
+.editing header {
+	color: white !important;
 }
 article header {
 	padding-left: 0;

--- a/www/css/gar.css
+++ b/www/css/gar.css
@@ -16,7 +16,7 @@ article.highlight {
 	background-color: #ffb8d5;
 	border-color: #ef93c5;
 }
-article.editing {
+.editing {
 	background: #b7bbb6 url('chevrons.png');
 	border-color: gray;
 	background-attachment: fixed;

--- a/www/css/glass.css
+++ b/www/css/glass.css
@@ -11,7 +11,7 @@ article, aside, .pagination, .popup-menu, .modal, .bmodal, .preview, #banner {
 a>b {
 	color: white;
 }
-article.editing {
+.editing {
 	background-color: rgba(145, 145, 145, 0.5);
 }
 blockquote, time, #FAQ {

--- a/www/css/higan.css
+++ b/www/css/higan.css
@@ -16,9 +16,9 @@ article.highlight {
 	background-color: rgba(44,44,51,.95);
 	border-color: #21212c;
 }
-article.editing {
-	background-color: rgba(51,41,41,.95);
-	border-color: #2c2121;
+.editing {
+	background-color: rgba(51,41,41,.95) !important;
+	border-color: #2c2121 !important;
 }
 b {
 	color: #808080;

--- a/www/css/mawaru.css
+++ b/www/css/mawaru.css
@@ -16,9 +16,9 @@ article.highlight {
 	background-color: #333;
 	border-color: #222;
 }
-article.editing {
-	background-color: #311;
-	border-color: #200;
+.editing {
+	background-color: #311 !important;
+	border-color: #200 !important;
 }
 b {
 	color: #666;

--- a/www/css/moe.css
+++ b/www/css/moe.css
@@ -16,9 +16,9 @@ article.highlight {
 	background-color: #d6bad0;
 	border-color: #ba9dbf;
 }
-article.editing {
-	background-color: #fa6;
-	border-color: #e95;
+.editing {
+	background-color: #fa6 !important;
+	border-color: #e95 !important;
 }
 b {
 	color: #117743;

--- a/www/css/moon.css
+++ b/www/css/moon.css
@@ -4,8 +4,8 @@ a:hover {
 article.highlight {
 	background-color: #f5f5f5;
 }
-article.editing {
-	background-color: #fa6;
+.editing {
+	background-color: #fa6 !important;
 }
 b.admin {
 	color: #f00000;

--- a/www/css/rave.css
+++ b/www/css/rave.css
@@ -5,7 +5,7 @@ a, blockquote a:hover, b.moderator {
 .bfloat > svg {
 	fill: black;
 }
-a:hover, blockquote a, .email b:hover, article.editing a:hover {
+a:hover, blockquote a, .email b:hover, .editing a:hover {
 	color: black;
     font-weight:bold;
 }
@@ -22,21 +22,21 @@ article.highlight, .preview, .popup-menu {
 	background-image: url(rave_bg.gif);
 	opacity: 0.9;
 }
-article.editing {
+.editing {
 	background-color: #cec952;
 	border-color: #aa3;
 	color: black;
 }
-article.editing a, article.editing header {
+.editing a, .editing header {
 	color: #222;
 }
-article.editing em {
+.editing em {
 	color: #656d28;
 }
-article.editing li {
+.editing li {
 	color: #ddd;
 }
-article.editing .themed {
+.editing .themed {
 	color: #333;
 }
 b.admin {

--- a/www/css/tavern.css
+++ b/www/css/tavern.css
@@ -4,7 +4,7 @@ a, blockquote a:hover, b.moderator {
 .bfloat > svg {
 	fill: #ef9d6a;
 }
-a:hover, blockquote a, .email b:hover, article.editing a:hover {
+a:hover, blockquote a, .email b:hover, .editing a:hover {
 	color: #ef9d6a;
 }
 article, aside, .modal, .bmodal, .pagination {
@@ -15,26 +15,26 @@ article.highlight, .preview, .popup-menu {
 	background: url(wood.jpg);
     color: white;
 }
-article.editing {
+.editing {
 	background:
         linear-gradient(
            rgba(239, 157, 106, 0.25),
            rgba(239, 157, 106, 0.25)
         ),
-        url(wood.jpg);
-	color: white;
+        url(wood.jpg) !important;
+	color: white !important;
 }
-article.editing a, article.editing header {
-	color: white;
+.editing a, .editing header {
+	color: white !important;
 }
-article.editing em {
-	color: #B7BA3E;
+.editing em {
+	color: #B7BA3E !important;
 }
-article.editing li {
-	color: white;
+.editing li {
+	color: white !important;
 }
-article.editing .themed {
-	color: white;
+.editing .themed {
+	color: white !important;
 }
 b.admin {
 	color: #f00000;

--- a/www/css/tea.css
+++ b/www/css/tea.css
@@ -16,10 +16,6 @@ article.highlight {
 	background-color: #b9ccb4;
 	border-color: #9fbf9d;
 }
-article.editing {
-	background-color: #f0e5ba;
-	border-color: #dbd1aa;
-}
 b {
 	color: #1a8522;
 }
@@ -83,6 +79,10 @@ hr {
 	background-color: #f6faf3;
 	border-right: 1px solid #e5e8e2;
 	border-bottom: 1px solid #e5e8e2;
+}
+.editing {
+	background-color: #f0e5ba !important;
+	border-color: #dbd1aa !important;
 }
 .omit {
 	color: #73806c;


### PR DESCRIPTION
This commit changes the color of the preview if the post you are previewing is still being edited.
![preview-edit](https://cloud.githubusercontent.com/assets/3243212/5118209/1546e40a-705f-11e4-8448-33025268f0cd.png)
I changed div to article because it seemed like the correct way to do it, and I don't think it causes any problem.
But I don't really know much about it so I can change it if it's bad.
