### PR TITLE
Reverse backlink highlight

### DIFF
--- a/client/hover.js
+++ b/client/hover.js
@@ -35,8 +35,19 @@ function preview_miru(event, num) {
 
 			if (post.is('section'))
 				bits = bits.slice(0, 3);
+			
+			//get id of parent post
+			var parent=event.target.parentNode.parentElement; //gets the parent of the links in: "Replies:"
+			parent= parent.id ? parent :parent.parentElement; //gets the parent of the normal links
+			
+			var newBits=bits.clone();
+			var reg = new RegExp('(a href="#'+parent.id+'">)(&gt;&gt;'+parent.id+')',"g"); //This regex searches for links to the original post
+			for(i=1;i<3;i++)	//check in both, reply text and normal text
+				if(newBits[i])
+					newBits[i].innerHTML=newBits[i].innerHTML.replace(reg,"$1<referenced>$2</referenced>");
+			
 			preview = $('<div class="preview"/>').append(
-					bits.clone());
+					newBits);
 			if((/^editing/).test(post[0].className))	//check if the post is being edited
 				preview[0].classList.add("editing");
 		}

--- a/www/css/base.css
+++ b/www/css/base.css
@@ -6,6 +6,9 @@ a.nope, a.nope:hover {
 	color: inherit;
 	text-decoration: none;
 }
+a > referenced{
+	border: 2px solid orange;
+}
 article, aside {
 	display: table;
 	margin: 2px;


### PR DESCRIPTION
Implements #93.
I couldn't find a better way to search for the parent.
Also the regex will fail if there are no `>>` before the link, I did it like this because I saw other parts of the code that also check for them, but I can change it if needed.
