### PR TITLE
fix random small thumbnails

### DIFF
--- a/imager/daemon.js
+++ b/imager/daemon.js
@@ -391,7 +391,7 @@ function identify(stream, cb) {
 					msg = 'unsupported';
 				return cb(msg);
 			}
-			const m = out.toString().trim().match(/(\d+)x(\d+)/);
+			const m = out.toString().trim().match(/ (\d+)x(\d+)/);
 			if (!m)
 				return cb('dims_fail');
 			else {


### PR DESCRIPTION
It's always the smallest things.
The following is the output of a wrong dimensioned image.
`` -=>/tmp/magick-75x5siPb PNG 150x150 ``
It was parsing the 75x5 instead of the 150x150.

I made it redo the same thumbnail until it got a wrong dimension, and it went for more than 10k passes  so I'm pretty sure this regex works.