### PR TITLE
Post preview

### DIFF
--- a/client/hover.js
+++ b/client/hover.js
@@ -5,34 +5,33 @@
 var $ = require('jquery'),
 	Backbone = require('backbone'),
 	main = require('./main'),
-	options = require('./options');
+	options = require('./options'),
+	article = require('./posts').Article,
+	state = require('./state');
 
 // Centralised mousemove target tracking
 var mousemove = exports.mousemove = new Backbone.Model({
 	id: 'mousemove',
-	target: null
+	/*Logging only the target isn't a option because change:target doesn't seem to fire in some cases where the target
+	 is too similar for example changing between two post links (>>XXX) directly*/
+	event: null
 });
 
-if (!main.isMobile) {
-	main.$doc.on('mousemove', function(e) {
-		mousemove.set('target', e.target);
-	});
-}
 var ImageHoverView = Backbone.View.extend({
 	initialize: function() {
-		this.listenTo(this.model,'change:target', this.check);
+		this.listenTo(this.model,'change:event', this.check);
 		this.listenTo(options, 'imageClicked', function() {
 			this.$el.empty();
 		});
 	},
 
-	check: function(model, target) {
+	check: function(model, event) {
 		// Disabled in options
 		if (!options.get('imageHover'))
 			return;
-		var $target = $(target);
+		var $target = $(event.target);
 		if (!$target.is('img') || $target.hasClass('expanded'))
-			return this.$el.empty();
+			return this.$el.children().remove("img,video");
 		const src = $target.closest('a').attr('href'),
 			isWebm = /\.webm$/.test(src);
 		// Nothing to preview for PDF or MP3
@@ -48,10 +47,102 @@ var ImageHoverView = Backbone.View.extend({
 		}).appendTo(this.$el.empty());
 	}
 });
+var PostPreview = article.extend({
+	initialize: function () {
+		this.listenTo(this.model, {
+			'change:body': this.render,
+			'change:editing': this.render,
+			'change:image': this.render
+		});
+		this.initCommon();
+	},
+	render: function () {
+		main.oneeSama.links = this.model.get('links');
+		this.setElement(main.oneeSama.mono(this.model.attributes));
+		this.$el.addClass('preview');
+		this.$el.append(this.$backlinks);
+		this.trigger("update",this.$el);
+		return this;
+	}
+});
+var HoverPostView = Backbone.View.extend({
+	previewView: null,
+	targetPos:null,
+	initialize: function() {
+		this.listenTo(this.model,'change:event', this.check);
+	},
+	check: function(model, event) {
+		var $target = $(event.target);
+		if ($target.is('a.history')){
+			var m = event.target.text.match(/^>>(\d+)/);
+			if (m) {
+				var post = state.posts.get(m[1]);
+				this.previewView = new PostPreview({model: post});
+				this.targetPos = $target.position();
+
+				//If the post changes we update the preview
+				this.listenTo(this.previewView, 'update', this.render);
+				this.previewView.render();
+
+				var modelref = this;
+				$target.one('mouseleave click',function(){
+					modelref.remove();
+				});
+			}
+		}
+	},
+	remove: function() {
+		if (this.previewView) {
+			this.targetPos = null;
+			this.previewView.remove();
+			this.stopListening(this.previewView);
+			this.$el.children().remove('.preview');
+			this.previewView = null;
+		}
+	},
+	render: function($el) {
+		$el.css(position_preview(this.targetPos,$el));
+		$el.appendTo(this.$el.empty());
+	}
+});
+function position_preview(targetPos,$el){
+	$el.hide();
+	$(document.body).append($el);
+	var w = $el.width();
+	var h = $el.height();
+	$el.detach().show();
+
+	var $w = $(window);
+	var l = targetPos.left -$w.scrollLeft();
+	var t = targetPos.top -$w.scrollTop()-h-17;
+
+	//If it get cut at the top, put it below the link
+	if(t<0)
+		t+=h+34;
+
+	//if it gets cut to the right push it to the left.
+	var overflowR = l+w-$w.innerWidth();
+	if(overflowR>-30)
+		l = Math.max(0,l-overflowR-30);
+
+	return {left: l,top: t};
+}
 
 if (!main.isMobile) {
+	var ltarget;
+	main.$doc.on('mousemove', function(e) {
+		if(e.target!=ltarget) {
+			mousemove.set('event', e);
+			ltarget= e.target;
+		}
+	});
+	var $hover =document.getElementById('hover_overlay');
 	new ImageHoverView({
 		model: mousemove,
-		el: document.getElementById('hover_overlay')
+		el: $hover
+	});
+	new HoverPostView({
+		model: mousemove,
+		el: $hover
 	});
 }

--- a/client/main.js
+++ b/client/main.js
@@ -92,3 +92,4 @@ require('./client');
 
 // Load auxilary modules
 require('./history');
+require('./hover');

--- a/less/base.less
+++ b/less/base.less
@@ -129,7 +129,7 @@ h3 {
 	pointer-events: none;
 	display: flex;
 	z-index: 300;
-	img, video {
+	& > img, & > video {
 		max-height: 100%;
 		max-width: 100%;
 		margin: auto auto;


### PR DESCRIPTION
Comparing it to the old client in this one:
 - If you preview a post with an expanded image, you see the preview  with a non expanded image.
 - Now preview updates as the post is edited.

The first lines of post_preview are copied from the old client, I deducted they force the element to calculate width and height, I don't know if there is a better way.

In the preview you can see links with (you) that you don't see in the normal thread, they are correct so I don't think it's a problem.

I didn't know how to go about what you said of not using the hoverOverlay as an element of the view.
I can make it so it copies the element of the postPreview view, but then I had to make it store a ref to hoverOverlay anyway, and we would have two views with the exact same element so it doesn't feel right with me, the other idea I had was to unify the two views in one, but that was a little strange so I would prefer some input on it. Some pointers on this would be appreciated.