### PR TITLE
Pass links in post update

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -94,6 +94,7 @@ dispatcher[common.UPDATE_POST] = function(msg) {
 		model = state.posts.get(num);
 
 	if (model) {
+		model.addLinks(links);
 		model.set({
 			body: model.get('body') + msg[1],
 			state: msgState

--- a/client/posts/models.js
+++ b/client/posts/models.js
@@ -30,6 +30,18 @@ exports.Post = Backbone.Model.extend({
 		// Remove from post collection
 		state.posts.remove(this);
 	},
+	addLinks: function(links){
+		if(!links)
+			return;
+		var old = this.get('links');
+		if(!old)
+			return this.set({links: links});
+		_.extend(old,links);
+		this.set({links:old});
+		//If we get here we changed something for sure, but as we are using the same ref backbone will ignore it
+		//so we have to force the event to trigger.
+		this.trigger('change:links',this,old);
+	},
 
 	// Pass this post's links to the central model
 	forwardLinks: function(model, links) {


### PR DESCRIPTION
This fixes what you said in the PostPreview PR about links not getting added to the stateLinkerCore if they weren't there at the start of the post.

I didn't find when the post model links where updated, and I found that the old client was updating them here so I just updated them here, if there is a reason you chose not to do this please say so.

Also I don't know if there is a better way to push them into links, one that doesn't force us to manually trigger the event.