### PR TITLE
Fix option exporting to work on Firefox

### DIFF
--- a/client/options.js
+++ b/client/options.js
@@ -171,14 +171,13 @@ var OptionsView = Backbone.View.extend({
 	},
 	// Dump options to file
 	export() {
-		var a = document.createElement('a');
+		var a = document.getElementById('export')
 		a.setAttribute('href', window.URL
 			.createObjectURL(new Blob([JSON.stringify(localStorage)], {
 				type: 'octet/stream'
 			}))
 		);
 		a.setAttribute('download', 'meguca-config.json');
-		a.click();
 	},
 	// Import options from file
 	import(event) {


### PR DESCRIPTION
Tested to work on Firefox 38.0 and Chromium 43.0.

Fixes bakape#164.