### PR TITLE
calculate favicons from post visibility and scrolling

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -68,7 +68,7 @@ export function insertPost(data: PostData) {
 		last.after(view.el)
 	}
 
-	postAdded()
+	postAdded(model)
 	incrementPostCount(true, "image" in data)
 }
 

--- a/client/db.ts
+++ b/client/db.ts
@@ -1,6 +1,6 @@
 // IndexedDB database controller
 
-const dbVersion = 5
+const dbVersion = 6
 
 let db: IDBDatabase
 
@@ -15,6 +15,7 @@ const postStores = [
 	"mine",   // Posts created by this client
 	"hidden", // Posts hidden by client
 	"seen",   // Replies to the user's posts that have already been seen
+	"seenPost", // Posts that the user has viewed or scrolled past
 ]
 
 // Open a connection to the IndexedDB database
@@ -79,6 +80,14 @@ function upgradeDB(event: IDBVersionChangeEvent) {
 			// Can't modify data during an upgrade, so do it right after the
 			// "upgrade" completes
 			setTimeout(() => addObj("main", { id: "mascot" }), 1000)
+			break
+		case 5:
+			if(db.objectStoreNames.contains("seenPost")) {
+				break
+			}
+			db.createObjectStore("seenPost", { autoIncrement: true })
+				.createIndex("expires", "expires")
+
 			break
 	}
 }

--- a/client/page/common.ts
+++ b/client/page/common.ts
@@ -4,6 +4,7 @@ import { PostData, fileTypes, PostLink } from "../common"
 import { Post, PostView } from "../posts"
 import lang from "../lang"
 import { notifyAboutReply } from "../ui"
+import { postAdded } from "../ui/tab"
 import { pluralize } from "../util"
 import { posterName } from "../options"
 
@@ -53,6 +54,8 @@ export function extractPost(
 	const { model: { links, backlinks, image } } = view
 	localizeLinks(links, view, true)
 	localizeLinks(backlinks, view, false)
+	postAdded(model)
+
 
 	if (image) {
 		const should = options.hideThumbs

--- a/client/posts/model.ts
+++ b/client/posts/model.ts
@@ -3,7 +3,7 @@ import { extend } from '../util'
 import Collection from './collection'
 import PostView from './view'
 import { SpliceResponse } from '../client'
-import { mine } from "../state"
+import { mine, seenPosts, storeSeenPost } from "../state"
 import { notifyAboutReply } from "../ui"
 import { PostData, TextState, PostLink, Command, ImageData } from "../common"
 
@@ -35,6 +35,7 @@ export class Post extends Model implements PostData {
 	constructor(attrs: PostData) {
 		super()
 		extend(this, attrs)
+		this.seenOnce = seenPosts.has(this.id)
 
 		// All kinds of interesting races can happen, so best ensure a model
 		// always has the state object defined
@@ -193,6 +194,7 @@ export class Post extends Model implements PostData {
 		}
 
 		this.seenOnce = this.view.scrolledPast()
+		storeSeenPost(this.id)
 		return this.seenOnce
 	}
 }

--- a/client/posts/model.ts
+++ b/client/posts/model.ts
@@ -130,6 +130,8 @@ export class Post extends Model implements PostData {
 	}
 
 	public isReply() {
+		if(!this.links)
+			return false
 		for (let [id] of this.links) {
 			if (!mine.has(id)) {
 				continue
@@ -194,7 +196,10 @@ export class Post extends Model implements PostData {
 		}
 
 		this.seenOnce = this.view.scrolledPast()
-		storeSeenPost(this.id)
+		if(this.seenOnce) {
+			storeSeenPost(this.id)
+		}
+		
 		return this.seenOnce
 	}
 }

--- a/client/posts/model.ts
+++ b/client/posts/model.ts
@@ -11,6 +11,7 @@ import { PostData, TextState, PostLink, Command, ImageData } from "../common"
 export class Post extends Model implements PostData {
 	collection: Collection
 	view: PostView
+	seenOnce: boolean
 
 	// PostData properties
 	public op: number
@@ -122,12 +123,19 @@ export class Post extends Model implements PostData {
 	// Check if this post replied to one of the user's posts and trigger
 	// handlers
 	public checkRepliedToMe() {
+		if(this.isReply()) {
+			notifyAboutReply(this)
+		}
+	}
+
+	public isReply() {
 		for (let [id] of this.links) {
 			if (!mine.has(id)) {
 				continue
 			}
-			notifyAboutReply(this)
+			return true
 		}
+		return false
 	}
 
 	// Insert data about another post linking this post into the model
@@ -173,6 +181,19 @@ export class Post extends Model implements PostData {
 	public setDeleted() {
 		this.deleted = true
 		this.view.renderDeleted()
+	}
+
+	public seen() {
+		if(this.seenOnce) {
+			return true
+		}
+
+		if(document.hidden) {
+			return false
+		}
+
+		this.seenOnce = this.view.scrolledPast()
+		return this.seenOnce
 	}
 }
 

--- a/client/posts/view.ts
+++ b/client/posts/view.ts
@@ -66,6 +66,14 @@ export default class PostView extends ImageHandler {
         this.model.view = this.model = null
     }
 
+    // check if we can see the post or have scrolled past it
+    public scrolledPast() {
+        const rect = this.el.getBoundingClientRect(),
+            viewW = document.documentElement.clientWidth,
+            viewH = document.documentElement.clientHeight;
+        return rect.bottom < viewH && rect.left > 0 && rect.left < viewW
+    }
+
     // Replace the current body with a reparsed fragment
     public reparseBody() {
         const bq = this.el.querySelector("blockquote")

--- a/client/state.ts
+++ b/client/state.ts
@@ -60,6 +60,9 @@ export const posts = new PostCollection()
 // Posts I made in any tab
 export let mine: Set<number>
 
+// Posts that the user has already seen or scrolled past
+export let seenPosts: Set<number>
+
 // Replies to this user's posts the user has already seen
 export let seenReplies: Set<number>
 
@@ -89,6 +92,8 @@ export function loadFromDB(): Promise<Set<number>[]> {
 			mine = new Set(ids)),
 		readIDs("seen").then(ids =>
 			seenReplies = new Set(ids)),
+		readIDs("seenPost").then(ids =>
+			seenPosts = new Set(ids)),
 		readIDs("hidden").then((ids) =>
 			hidden = new Set(ids)),
 	])
@@ -104,6 +109,11 @@ export function storeMine(id: number) {
 export function storeSeenReply(id: number) {
 	seenReplies.add(id)
 	storeID("seen", id, thirtyDays)
+}
+
+export function storeSeenPost(id: number) {
+	seenReplies.add(id)
+	storeID("seenPost", id, thirtyDays)
 }
 
 // Store the ID of a post or thread to hide

--- a/client/ui/notification.ts
+++ b/client/ui/notification.ts
@@ -19,7 +19,7 @@ export default function notifyAboutReply(post: Post) {
 	if (!document.hidden) {
 		return
 	}
-	repliedToMe()
+	repliedToMe(post)
 
 	const re = !options.notification
 		|| typeof Notification !== "function"

--- a/client/ui/tab.ts
+++ b/client/ui/tab.ts
@@ -110,7 +110,7 @@ export default () => {
 	}
 
 	document.addEventListener("scroll", () => {
-		if(recalcPending) {
+		if(recalcPending || document.hidden) {
 			return
 		}
 		recalcPending = true

--- a/client/ui/tab.ts
+++ b/client/ui/tab.ts
@@ -2,7 +2,7 @@
 
 import { connSM, connState } from "../connection"
 import { Post } from "../posts"
-import { posts } from "../state"
+import { posts, page } from "../state"
 
 const titleEl = document.head.querySelector("title"),
 	faviconEl = document.getElementById("favicon"),
@@ -122,6 +122,12 @@ export default () => {
 	for (let state of [connState.dropped, connState.desynced]) {
 		connSM.on(state, delayedDiscoRender)
 	}
+
+	page.onChange("thread", () => {
+		unseenPosts = 0
+		unseenReplies = false
+		resolve()
+	})
 
 	document.addEventListener("scroll", () => {
 		if(recalcPending || document.hidden) {


### PR DESCRIPTION
at some point in the future this could use [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) instead of recomputing on scroll, but that's still too new for now. But recomputation is capped to once every 200ms and skips already-seen posts.