### PR TITLE
Add flashing colors to dice rolls

### DIFF
--- a/client/posts/render/body.ts
+++ b/client/posts/render/body.ts
@@ -400,6 +400,7 @@ function parseCommand(bit: string, { commands, state }: PostData): string {
         return "#" + bit
     }
 
+    let formatting = "<strong>"
     let inner: string
     switch (bit) {
         case "flip":
@@ -420,6 +421,7 @@ function parseCommand(bit: string, { commands, state }: PostData): string {
             if (parseInt(m[1]) > 10 || parseInt(m[2]) > 10000) {
                 return "#" + bit
             }
+            const sides = parseInt(m[2])
 
             const rolls = commands[state.iDice++].val as number[]
             inner = ""
@@ -434,9 +436,57 @@ function parseCommand(bit: string, { commands, state }: PostData): string {
             if (rolls.length > 1) {
                 inner += " = " + sum
             }
+
+            formatting = getRollFormatting(rolls.length, sides, sum)
     }
 
-    return `<strong>#${bit} (${inner})</strong>`
+    return `${formatting}#${bit} (${inner})</strong>`
+}
+
+function getRollFormatting(numberOfDice: number, facesPerDie: number, sum: number): string {
+    const maxRoll = numberOfDice * facesPerDie
+    // no special formatting for small rolls
+    if (maxRoll < 10 || facesPerDie == 1) {
+        return "<strong>"
+    }
+
+    if (numberOfDice == 1 && facesPerDie == sum && sum == 7777) { // Marrying navy-tan!
+        return "<strong class=\"rainbow_roll\">Congrats! You get to marry navy-tan! ";
+    } else if (maxRoll == sum) {
+        return "<strong class=\"super_roll\">";
+    } else if (sum == 1) {
+        return "<strong class=\"kuso_roll\">";
+    } else if (sum == 69 || sum == 6969) {
+        return "<strong class=\"lewd_roll\">";
+    } else if (checkEm(sum)) {
+        if (sum < 100) {
+            return "<strong class=\"dubs_roll\">";
+        } else if (sum < 1000) {
+            return "<strong class=\"trips_roll\">";
+        } else if (sum < 10000) {
+            return "<strong class=\"quads_roll\">";
+        } else {// QUINTS!!!
+            return "<strong class=\"rainbow_roll\">";
+        }
+    }
+    return "<strong>"
+}
+
+// If num is made of the same digit repeating
+function checkEm(num: number): boolean {
+    if (num < 10) {
+        return false
+    }
+    const digit = num % 10
+    while (true) {
+        num = Math.floor(num/10)
+        if (num == 0) {
+            return true
+        }
+        if (num % 10 != digit) {
+            return false
+        }
+    }
 }
 
 // Format a synchronized time counter

--- a/client/posts/render/body.ts
+++ b/client/posts/render/body.ts
@@ -450,9 +450,7 @@ function getRollFormatting(numberOfDice: number, facesPerDie: number, sum: numbe
         return "<strong>"
     }
 
-    if (numberOfDice == 1 && facesPerDie == sum && sum == 7777) { // Marrying navy-tan!
-        return "<strong class=\"rainbow_roll\">Congrats! You get to marry navy-tan! ";
-    } else if (maxRoll == sum) {
+    if (maxRoll == sum) {
         return "<strong class=\"super_roll\">";
     } else if (sum == 1) {
         return "<strong class=\"kuso_roll\">";

--- a/go/src/meguca/templates/body.go
+++ b/go/src/meguca/templates/body.go
@@ -450,7 +450,7 @@ func (c *bodyContext) parseCommands(bit string) {
 		return
 	}
 
-    formatting := "<strong>"
+	formatting := "<strong>"
 	inner := make([]byte, 0, 32)
 	val := c.Commands[c.state.iDice]
 	switch bit {
@@ -478,9 +478,9 @@ func (c *bodyContext) parseCommands(bit string) {
 
 		// Validate dice
 		m := common.DiceRegexp.FindStringSubmatch(bit)
-        rolls := 1
+		rolls := 1
 		if m[1] != "" {
-            var err error
+			var err error
 			if rolls, err = strconv.Atoi(m[1]); err != nil || rolls > 10 {
 				c.writeInvalidCommand(bit)
 				return
@@ -506,10 +506,10 @@ func (c *bodyContext) parseCommands(bit string) {
 			inner = strconv.AppendUint(inner, sum, 10)
 		}
 
-        formatting = getRollFormatting(uint64(rolls), uint64(sides), sum)
+		formatting = getRollFormatting(uint64(rolls), uint64(sides), sum)
 	}
 
-    c.string(formatting)
+	c.string(formatting)
 	c.string(`#`)
 	c.string(bit)
 	c.string(` (`)
@@ -518,49 +518,49 @@ func (c *bodyContext) parseCommands(bit string) {
 }
 
 func getRollFormatting(numberOfDice uint64, facesPerDie uint64, sum uint64) string {
-    maxRoll := numberOfDice * facesPerDie
-    // no special formatting for small rolls
-    if maxRoll < 10 || facesPerDie == 1 {
-        return "<strong>"
-    }
+	maxRoll := numberOfDice * facesPerDie
+	// no special formatting for small rolls
+	if maxRoll < 10 || facesPerDie == 1 {
+		return "<strong>"
+	}
 
-    if numberOfDice == 1 && facesPerDie == sum && sum == 7777 { // Marrying navy-tan!
-        return "<strong class=\"rainbow_roll\">Congrats! You get to marry navy-tan! ";
-    } else if maxRoll == sum {
-        return "<strong class=\"super_roll\">";
-    } else if sum == 1 {
-        return "<strong class=\"kuso_roll\">";
-    } else if sum == 69 || sum == 6969 {
-        return "<strong class=\"lewd_roll\">";
-    } else if checkEm(sum) {
-        if sum < 100 {
-            return "<strong class=\"dubs_roll\">";
-        } else if sum < 1000 {
-            return "<strong class=\"trips_roll\">";
-        } else if sum < 10000 {
-            return "<strong class=\"quads_roll\">";
-        } else {// QUINTS!!!
-            return "<strong class=\"rainbow_roll\">";
-        }
-    }
-    return "<strong>"
+	if numberOfDice == 1 && facesPerDie == sum && sum == 7777 { // Marrying navy-tan!
+		return "<strong class=\"rainbow_roll\">Congrats! You get to marry navy-tan! "
+	} else if maxRoll == sum {
+		return "<strong class=\"super_roll\">"
+	} else if sum == 1 {
+		return "<strong class=\"kuso_roll\">"
+	} else if sum == 69 || sum == 6969 {
+		return "<strong class=\"lewd_roll\">"
+	} else if checkEm(sum) {
+		if sum < 100 {
+			return "<strong class=\"dubs_roll\">"
+		} else if sum < 1000 {
+			return "<strong class=\"trips_roll\">"
+		} else if sum < 10000 {
+			return "<strong class=\"quads_roll\">"
+		} else { // QUINTS!!!
+			return "<strong class=\"rainbow_roll\">"
+		}
+	}
+	return "<strong>"
 }
 
 // If num is made of the same digit repeating
 func checkEm(num uint64) bool {
-    if num < 10 {
-        return false
-    }
-    digit := num % 10
-    for {
-        num /= 10
-        if num == 0 {
-            return true
-        }
-        if num % 10 != digit {
-            return false
-        }
-    }
+	if num < 10 {
+		return false
+	}
+	digit := num % 10
+	for {
+		num /= 10
+		if num == 0 {
+			return true
+		}
+		if num%10 != digit {
+			return false
+		}
+	}
 }
 
 // Format a synchronized time counter

--- a/go/src/meguca/templates/body.go
+++ b/go/src/meguca/templates/body.go
@@ -524,9 +524,7 @@ func getRollFormatting(numberOfDice uint64, facesPerDie uint64, sum uint64) stri
 		return "<strong>"
 	}
 
-	if numberOfDice == 1 && facesPerDie == sum && sum == 7777 { // Marrying navy-tan!
-		return "<strong class=\"rainbow_roll\">Congrats! You get to marry navy-tan! "
-	} else if maxRoll == sum {
+	if maxRoll == sum {
 		return "<strong class=\"super_roll\">"
 	} else if sum == 1 {
 		return "<strong class=\"kuso_roll\">"

--- a/go/src/meguca/templates/body_test.go
+++ b/go/src/meguca/templates/body_test.go
@@ -144,22 +144,44 @@ func TestRenderBody(t *testing.T) {
 		{
 			name: "single roll dice",
 			in:   "#d20",
-			out:  "<strong>#d20 (22)</strong>",
+			out:  "<strong>#d20 (21)</strong>",
 			commands: []common.Command{
 				{
 					Type: common.Dice,
-					Dice: []uint16{22},
+					Dice: []uint16{21},
+				},
+			},
+		},
+		{
+			name: "dubs roll dice",
+			in:   "#d20",
+			out:  "<strong class=\"dubs_roll\">#d20 (11)</strong>",
+			commands: []common.Command{
+				{
+					Type: common.Dice,
+					Dice: []uint16{11},
+				},
+			},
+		},
+		{
+			name: "max roll dice",
+			in:   "#d20",
+			out:  "<strong class=\"super_roll\">#d20 (20)</strong>",
+			commands: []common.Command{
+				{
+					Type: common.Dice,
+					Dice: []uint16{20},
 				},
 			},
 		},
 		{
 			name: "multiple roll dice",
 			in:   "#2d20",
-			out:  "<strong>#2d20 (22 + 33 = 55)</strong>",
+			out:  "<strong>#2d20 (21 + 33 = 54)</strong>",
 			commands: []common.Command{
 				{
 					Type: common.Dice,
-					Dice: []uint16{22, 33},
+					Dice: []uint16{21, 33},
 				},
 			},
 		},

--- a/less/common.mix.less
+++ b/less/common.mix.less
@@ -10,6 +10,91 @@ blockquote strong {
 	color: mix(@body, @link);
 }
 
+.super_roll {
+    animation: pink_blinker 0.4s linear 25;
+    color: pink;
+}
+@keyframes pink_blinker {
+    50% {
+        color: deeppink
+    }
+}
+
+.lewd_roll {
+    animation: lewd_blinker 0.7s linear 15;
+    color: pink;
+}
+@keyframes lewd_blinker {
+    50% {
+        color: #FFD6E1
+    }
+}
+
+.kuso_roll {
+    animation: brown_blinker 1s linear 10;
+    color: #825025;
+}
+@keyframes brown_blinker {
+    50% {
+        opacity: 0.7
+    }
+}
+
+.dubs_roll {
+    animation: blue_blinker 0.4s linear 25;
+    color: aqua;
+}
+@keyframes blue_blinker {
+    50% {
+        color: blue
+    }
+}
+
+.trips_roll {
+    animation: yellow_blinker 0.4s linear 25;
+    color: yellow;
+}
+@keyframes yellow_blinker {
+    50% {
+        color: darkorange
+    }
+}
+
+.quads_roll {
+    animation: green_blinker 0.4s linear 25;
+    color: lime;
+}
+@keyframes green_blinker {
+    50% {
+        color: darkgreen
+    }
+}
+
+.rainbow_roll {
+    animation: rainbow_blinker 2s linear 5;
+    color: red;
+}
+@keyframes rainbow_blinker {
+    14% {
+        color: orange
+    }
+    28% {
+        color: yellow
+    }
+    42% {
+        color: green
+    }
+    57% {
+        color: blue
+    }
+    71% {
+        color: indigo
+    }
+    85% {
+        color: violet
+    }
+}
+
 .modal hr {
 	border-top: 1px solid @link;
 }


### PR DESCRIPTION
Dice are only formatted if there are at least 2 sides per die, and the maximum possible total was at least 10.  ie \#10d1 would not be formatted, but \#5d2 could be.  The flashing animations go on for about 10 seconds then stop, because CSS animations can cause a lot of CPU usage.

Rolling a 1 makes the roll brown.
Rolling the maximum value makes the roll pink.
Rolling dubs makes the die blue (trips are yellow, quads are green, quints are rainbow).
Rolling a 69 or 6969 makes the roll light pink.
Rolling a 7777 on a d7777 makes the roll rainbow and adds a special message.