### PR TITLE
fix kusorolls for multiple dice

### DIFF
--- a/client/posts/render/body.ts
+++ b/client/posts/render/body.ts
@@ -452,7 +452,7 @@ function getRollFormatting(numberOfDice: number, facesPerDie: number, sum: numbe
 
     if (maxRoll == sum) {
         return "<strong class=\"super_roll\">";
-    } else if (sum == 1) {
+    } else if (sum == numberOfDice) {
         return "<strong class=\"kuso_roll\">";
     } else if (sum == 69 || sum == 6969) {
         return "<strong class=\"lewd_roll\">";

--- a/go/src/meguca/templates/body.go
+++ b/go/src/meguca/templates/body.go
@@ -526,7 +526,7 @@ func getRollFormatting(numberOfDice uint64, facesPerDie uint64, sum uint64) stri
 
 	if maxRoll == sum {
 		return "<strong class=\"super_roll\">"
-	} else if sum == 1 {
+	} else if sum == numberOfDice {
 		return "<strong class=\"kuso_roll\">"
 	} else if sum == 69 || sum == 6969 {
 		return "<strong class=\"lewd_roll\">"


### PR DESCRIPTION
The kuso_roll class was only being applied to rolls of 1, but it will now be applied to a roll that equals the number of dice rolled.  ie, when each die rolls a 1.

![screenshot from 2018-01-14 20-03-51](https://user-images.githubusercontent.com/26758560/34923101-a0a4b05c-f966-11e7-9a06-604023571281.png)
