### PR TITLE
Optimize renderTime

### DIFF
--- a/client/options/loop.ts
+++ b/client/options/loop.ts
@@ -23,9 +23,9 @@ export default () => {
 	}
 }
 
-// Rerender time every minute
+// Rerender time every minute, if relative time is set
 setInterval(() => {
-	if (!page.catalog) {
+	if (options.relativeTime && !page.catalog) {
 		renderTime()
 	}
 }, 60000)


### PR DESCRIPTION
relative timestamps: read the DOM to check if a mutation is necessary
absolute timestamps: only update the tooltips on mouseover