### PR TITLE
make: Added check option for NixOS doCheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ test:
 test_no_race:
 	go test -p 1 meguca/...
 
+check: test
+
 upgrade_v4: generate
 	go get -v github.com/dancannon/gorethink
 	$(MAKE) -C scripts/migration/3to4 upgrade


### PR DESCRIPTION
NixOS has a doCheck option when building packages that does `make check` instead of `make test`.