### PR TITLE
travis: enable updating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 services: docker
+before_install:
+  npm i npm@latest -g
 script:
   - docker build -t meguca_test .
   - docker run -t --entrypoint scripts/docker_test.sh meguca_test
@@ -8,3 +10,6 @@ notifications:
       - scorpid33@gmail.com
     on_success: never
     on_failure: always
+addons:
+    apt:
+      update: true


### PR DESCRIPTION
```
You can opt into running apt-get update by setting this in your .travis.yml file:
  addons:
    apt:
      update: true
```
```
npm WARN notice [SECURITY] lodash has 1 low vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=lodash&version=4.17.4 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
npm WARN notice [SECURITY] lodash has 1 low vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=lodash&version=4.17.4 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
npm WARN notice [SECURITY] lodash has 1 low vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=lodash&version=4.17.4 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
npm WARN notice [SECURITY] atob has 1 moderate vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=atob&version=1.1.3 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
npm WARN notice [SECURITY] stringstream has 1 moderate vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=stringstream&version=0.0.5 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
npm WARN notice [SECURITY] minimatch has 1 high vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=minimatch&version=0.2.14 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
npm WARN notice [SECURITY] minimatch has 1 high vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=minimatch&version=2.0.10 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
npm WARN notice [SECURITY] hoek has 1 moderate vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=hoek&version=2.16.3 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
npm WARN notice [SECURITY] lodash has 1 low vulnerability. Go here for more details: https://nodesecurity.io/advisories?search=lodash&version=1.0.2 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
```