### PR TITLE
client: Remove '&' option from embed

### DIFF
--- a/client/posts/embed.ts
+++ b/client/posts/embed.ts
@@ -85,6 +85,7 @@ async function fetchHookTube(el: Element): Promise<void> {
 			.split(".com/").pop()
 			.split("watch?v=").pop()
 			.split("embed/").pop()
+			.split("&").shift()
 			.split("#").shift()
 			.split("?").shift(),
 		[data, err] = await fetchJSON<any>(


### PR DESCRIPTION
In certain cases, such as `https://www.youtube.com/watch?v=TrgxHDoe8gA&`, can mess up the embed.