### PR TITLE
log, db: Only enable SMTP if email is enabled

### DIFF
--- a/go/src/meguca/db/config.go
+++ b/go/src/meguca/db/config.go
@@ -27,9 +27,7 @@ func loadConfigs() error {
 		return err
 	}
 	config.Set(conf)
-	if conf.EmailErr {
-		mLog.Init(mLog.Email)
-	}
+	mLog.Init(mLog.Email)
 
 	return Listen("config_updates", updateConfigs)
 }
@@ -159,9 +157,7 @@ func updateConfigs(data string) error {
 		return util.WrapError("reloading configuration", err)
 	}
 	config.Set(conf)
-	if conf.EmailErr {
-		mLog.Update()
-	}
+	mLog.Update()
 
 	return recompileTemplates()
 }


### PR DESCRIPTION
Here's a slightly saner way to ensure it doesn't email errors or warn of an incorrect email if emailing errors isn't enabled.
I'll submit an issue to upstream and maybe we can disable or change log levels for the email handler under certain conditions.