### PR TITLE
client: Add start and loop parameters, better errors, minor improvements

### DIFF
--- a/client/posts/embed.ts
+++ b/client/posts/embed.ts
@@ -1,5 +1,10 @@
 import { makeAttrs, makeFrag, escape, on, fetchJSON } from "../util"
 
+type HookTubeDoc = {
+	body?: string
+	error?: string
+}
+
 type OEmbedDoc = {
 	title?: string
 	html?: string
@@ -80,19 +85,13 @@ function proxyYoutube(el: Element): Promise<void> {
 async function fetchHookTube(el: Element): Promise<void> {
 	// Use a CORS proxy to work around javascript's cross-domain restrictions
 	const ref = el.getAttribute("href"),
-		url = "https://hooktube.com/embed/" + ref
-			.split(".com/").pop()
-			.split("watch?v=").pop()
-			.split("embed/").pop()
-			.split("&").shift()
-			.split("#").shift()
-			.split("?").shift(),
-		[data, err] = await fetchJSON<any>("https://cors-proxy.htmldriven.com/?url=" + url),
-		time = !ref.includes("t=") ? "" : "&t=" + ref
-			.split("t=").pop()
-			.split("&").shift()
-			.split("#").shift()
-			.split("?").shift()
+		id = strip(ref.split(".com/").pop().split("watch?v=").pop().split("embed/")),
+		params = (ref.includes("start=") ? "&start=" + strip(ref.split("start=")) : "") +
+			(ref.includes("t=") ?  "&t=" + strip(ref.split("t=")) : "") +
+			(ref.includes("loop=") ? "&loop=" + strip(ref.split("loop=")) : ""),
+		[data, err] = await fetchJSON<HookTubeDoc>("https://cors-proxy.htmldriven.com/?url=" +
+			"https%3A%2F%2Fhooktube.com%2Fapi%3Fmode%3Dvideo%26id%3D" + id),
+		body = JSON.parse(data.body)
 
 	if (err) {
 		el.textContent = format(err, provider.HookTube)
@@ -107,13 +106,26 @@ async function fetchHookTube(el: Element): Promise<void> {
 		return
 	}
 
-	el.textContent = format(new DOMParser()
-		.parseFromString(data.body, "text/html").
-		querySelectorAll('title')[0]
-		.innerText, provider.HookTube)
-	el.setAttribute("data-html",
-		encodeURIComponent(
-			`<iframe width="480" height="270" src="${url}?autoplay=false${time}" frameborder="0" allowfullscreen></iframe>`))
+	if (body.error) {
+		el.textContent = format(body.error, provider.HookTube)
+		el.classList.add("errored")
+		return
+	}
+
+	if (!body.json_1) {
+		el.textContent = format("Invalid YouTube video ID / Unknown error", provider.HookTube)
+		el.classList.add("errored")
+		return
+	}
+
+	el.textContent = format(body.json_1.title, provider.HookTube)
+	el.setAttribute("data-html", encodeURIComponent(
+		`<iframe width="480" height="270" src="https://hooktube.com/embed/` +
+		`${id}?autoplay=false${params}" frameborder="0" allowfullscreen></iframe>`))
+
+	function strip(s: string[]): string {
+		return s.pop().split("&").shift().split("#").shift().split("?").shift()
+	}
 }
 
 // fetcher for the noembed.com meta-provider


### PR DESCRIPTION
This is a little cleaner, and should take care of a few error cases.
I'm still trying to get in contact with the HookTube devs in the hope that maybe they'll enable CORS on the API server.