### PR TITLE
css: Hide banner overflow, unhide if mouse hover

### DIFF
--- a/less/common.mix.less
+++ b/less/common.mix.less
@@ -112,9 +112,16 @@ blockquote strong {
 	}
 }
 
-#banner{
+#banner {
 	background: fade(@postBG, 70%);
 	border-bottom: @border;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+#banner:hover {
+	overflow: visible;
 }
 
 b {


### PR DESCRIPTION
Fixes #728
Well, it's a bit of an ugly solution, but it'll work until you can do something smarter.