### PR TITLE
templates: Render formatting in board catalog posts

### DIFF
--- a/go/src/meguca/templates/board.qtpl
+++ b/go/src/meguca/templates/board.qtpl
@@ -98,6 +98,7 @@ allow caching of generated posts.
 {% func CatalogThreads(b []common.Thread, json []byte) %}{% stripspace %}
 	<div id="catalog">
 		{% for _, t := range b %}
+			{% code boardConfig := config.GetBoardConfigs(t.Board) %}
 			{% code idStr:= strconv.FormatUint(t.ID, 10) %}
 			{% code hasImage := t.Image != nil && t.Image.ThumbType != common.NoFile %}
 			<article id="p{%s= idStr %}" {% space %} {%= postClass(t.Post, t.ID) %} {% space %} data-id="{%s= idStr %}">
@@ -133,7 +134,7 @@ allow caching of generated posts.
 					「{%s t.Subject %}」
 				</h3>
 				<blockquote>
-					{%s t.Body %}
+					{%= body(t.Post, t.ID, t.Board, false, boardConfig.RbText, boardConfig.Pyu) %}
 				</blockquote>
 			</article>
 		{% endfor %}


### PR DESCRIPTION
Fixes #764
There's a caveat I need your help with, however.
Red/blue text and other formatting shows up fine in the catalog, however red/blue text seems to not work when in the index, or even in the thread OP for that matter. This is only an OP problem, other posts show red/blue fine, both in the thread and index.
Do you know how I can fix this?