### PR TITLE
common, server: Use HookTube JSON API and add error function

### DIFF
--- a/go/src/meguca/common/errors.go
+++ b/go/src/meguca/common/errors.go
@@ -82,11 +82,6 @@ func ErrInvalidBoard(board string) error {
 	return StatusError{fmt.Errorf("board `%s` does not exist", board), 404}
 }
 
-// Missing string
-func ErrMissingString(str string) error {
-	return StatusError{fmt.Errorf("expected string `%s` does not exist", str), 404}
-}
-
 // Returns, if client-caused error can be safely ignored and not logged
 func CanIgnoreClientError(err error) bool {
 recheck:

--- a/go/src/meguca/common/errors.go
+++ b/go/src/meguca/common/errors.go
@@ -82,6 +82,11 @@ func ErrInvalidBoard(board string) error {
 	return StatusError{fmt.Errorf("board `%s` does not exist", board), 404}
 }
 
+// Missing string
+func ErrMissingString(str string) error {
+	return StatusError{fmt.Errorf("expected string `%s` does not exist", str), 404}
+}
+
 // Returns, if client-caused error can be safely ignored and not logged
 func CanIgnoreClientError(err error) bool {
 recheck:


### PR DESCRIPTION
This should be a bit lighter on the server, and covers an error case in which it was possible for the title to not fetch on the /embed hooktube url.