### PR TITLE
common, server: Ignore invalid YouTube fetch on livestream, use GetVideoInfoFromID

### DIFF
--- a/go/src/meguca/common/errors.go
+++ b/go/src/meguca/common/errors.go
@@ -108,6 +108,7 @@ recheck:
 		"connection reset by peer",
 		"broken pipe",
 		"Error extracting sts from embedded url response",
+		"Unable to extract dash manifest: strconv.ParseInt: parsing \"rawcc\": invalid syntax",
 	} {
 		if strings.HasSuffix(s, suff) {
 			return true

--- a/go/src/meguca/server/router.go
+++ b/go/src/meguca/server/router.go
@@ -256,7 +256,7 @@ func youTubeData(w http.ResponseWriter, r *http.Request) {
 	ytid := extractParam(r, "id")
 	code, err := func() (code uint16, err error) {
 		code = 500
-		info, err := ytdl.GetVideoInfo("https://www.youtube.com/watch?v=" + ytid)
+		info, err := ytdl.GetVideoInfoFromID(ytid)
 
 		if err != nil {
 			return


### PR DESCRIPTION
Fixes #817