### PR TITLE
*: Implement echo formatting

### DIFF
--- a/client/common/index.ts
+++ b/client/common/index.ts
@@ -42,8 +42,9 @@ export type TextState = {
 	spoiler: boolean
 	quote: boolean
 	code: boolean
-	italic: boolean
 	bold: boolean
+	italic: boolean
+	echo: boolean
 	red: boolean
 	blue: boolean
 	haveSyncwatch: boolean

--- a/client/posts/model.ts
+++ b/client/posts/model.ts
@@ -59,6 +59,7 @@ export class Post extends Model implements PostData {
 			code: false,
 			bold: false,
 			italic: false,
+			echo: false,
 			red: false,
 			blue: false,
 			haveSyncwatch: false,
@@ -252,6 +253,7 @@ export class Post extends Model implements PostData {
 
 function endsWithTag(body: string): boolean {
 	const sl = body[body.length - 2]
+
 	switch (body[body.length - 1]) {
 		case ">":
 			return true
@@ -268,5 +270,13 @@ function endsWithTag(body: string): boolean {
 		case "b":
 			return sl === "^"
 	}
+
+	switch (body.slice(body.length - 3, body.length)) {
+		case "(((":
+			return true
+		case ")))":
+			return true
+	}
+
 	return false
 }

--- a/client/posts/posting/model.ts
+++ b/client/posts/posting/model.ts
@@ -49,6 +49,7 @@ export default class FormModel extends Post {
 				code: false,
 				bold: false,
 				italic: false,
+				echo: false,
 				red: false,
 				blue: false,
 				haveSyncwatch: false,

--- a/client/posts/view.ts
+++ b/client/posts/view.ts
@@ -67,9 +67,9 @@ export default class PostView extends ImageHandler {
 
     // Get the current Element for text to be written to
     private buffer(): Element {
-        const { state: { spoiler, quote, bold, italic, red, blue } } = this.model
+        const { state: { spoiler, quote, bold, italic, echo, red, blue } } = this.model
         let buf = this.el.querySelector("blockquote") as Element
-        for (let b of [quote, spoiler, bold, italic, red, blue]) {
+        for (let b of [quote, spoiler, bold, italic, echo, red, blue]) {
             if (b) {
                 buf = buf.lastElementChild
             }

--- a/go/src/meguca/config/config.go
+++ b/go/src/meguca/config/config.go
@@ -108,6 +108,7 @@ const defaultFAQ = `Supported upload file types are JPEG, PNG, APNG, WEBM, MP3, 
   ** for spoilers
   @@ for bold
   ~~ for italics
+  ((())) for echoes
   ^r for red text
   ^b for blue text
   ` + "``" + ` for programing code highlighting

--- a/go/src/meguca/templates/body_test.go
+++ b/go/src/meguca/templates/body_test.go
@@ -73,8 +73,8 @@ func TestRenderBody(t *testing.T) {
 		},
 		{
 			name: "nested formating",
-			in:   "foo** bar@@b~~a@@z^re^r^br^b**h~~",
-			out:  `foo<del> bar<b>b<i>a</i></b><i>z<span class="red">e</span><span class="blue">r</span></i></del><i>h</i>`,
+			in:   "foo** bar@@b~~a@@z^re^r^br^b(((s)))**h~~",
+			out:  `foo<del> bar<b>b<i>a</i></b><i>z<span class="red">e</span><span class="blue">r</span><span class="echo">(((s)))</span></i></del><i>h</i>`,
 		},
 		{
 			name:    "trailing empty open line",

--- a/less/ashita.less
+++ b/less/ashita.less
@@ -8,6 +8,7 @@
 @bold: #c5c8c6;
 @admin: #f00000;
 @mod: #9b5cff;
+@echo: blue;
 @red: @admin;
 @blue: #57e8ed;
 

--- a/less/common.mix.less
+++ b/less/common.mix.less
@@ -168,6 +168,11 @@ del {
 	color: @link;
 }
 
+.echo {
+    background-color: white;
+    color: @echo
+}
+
 .red {
 	color: @red;
 }

--- a/less/console.less
+++ b/less/console.less
@@ -8,6 +8,7 @@
 @bold: white;
 @admin: red;
 @mod: pink;
+@echo: blue;
 @red: @admin;
 @blue: #57e8ed;
 

--- a/less/egophobe.less
+++ b/less/egophobe.less
@@ -8,6 +8,7 @@
 @bold: #117743;
 @admin: #f00000;
 @mod: purple;
+@echo: blue;
 @red: @admin;
 @blue: #1048ff;
 

--- a/less/gar.less
+++ b/less/gar.less
@@ -8,6 +8,7 @@
 @bold: #555;
 @admin: #ff2385;
 @mod: #128e3c;
+@echo: blue;
 @red: #DF0101;
 @blue: #1048ff;
 

--- a/less/glass.less
+++ b/less/glass.less
@@ -8,6 +8,7 @@
 @bold: white;
 @admin: #f00000;
 @mod: #423756;
+@echo: blue;
 @red: @admin;
 @blue: #57e8ed;
 

--- a/less/gowno.less
+++ b/less/gowno.less
@@ -8,6 +8,7 @@
 @bold: #f7f3ed;
 @admin: #f00000;
 @mod: #9b5cff;
+@echo: blue;
 @red: @admin;
 @blue: #57e8ed;
 

--- a/less/higan.less
+++ b/less/higan.less
@@ -8,6 +8,7 @@
 @bold: #808080;
 @admin: #dc322f;
 @mod: #5f5faf;
+@echo: blue;
 @red: @admin;
 @blue: #57e8ed;
 

--- a/less/inumi.less
+++ b/less/inumi.less
@@ -8,6 +8,7 @@
 @bold: #c5c8c6;
 @admin: #f00000;
 @mod: #9775ff;
+@echo: blue;
 @red: @admin;
 @blue: #57e8ed;
 

--- a/less/mawaru.less
+++ b/less/mawaru.less
@@ -8,6 +8,7 @@
 @bold: #666;
 @admin: #f00;
 @mod: #ffff33;
+@echo: blue;
 @red: @admin;
 @blue: #57e8ed;
 

--- a/less/moe.less
+++ b/less/moe.less
@@ -8,6 +8,7 @@
 @bold: #117743;
 @admin: #f00000;
 @mod: purple;
+@echo: blue;
 @red: @admin;
 @blue: #1048ff;
 

--- a/less/moon.less
+++ b/less/moon.less
@@ -8,6 +8,7 @@
 @bold: black;
 @admin: #f00000;
 @mod: purple;
+@echo: blue;
 @red: @admin;
 @blue: #1048ff;
 

--- a/less/ocean.less
+++ b/less/ocean.less
@@ -8,6 +8,7 @@
 @border: 1px solid #262626;
 @admin: #15CFFA;
 @mod: #5f5faf;
+@echo: blue;
 @red: #bc0000;
 @blue: #5793ed;
 

--- a/less/rave.less
+++ b/less/rave.less
@@ -8,6 +8,7 @@
 @bold: black;
 @admin: red;
 @mod: black;
+@echo: blue;
 @red: @admin;
 @blue: #1048ff;
 

--- a/less/tavern.less
+++ b/less/tavern.less
@@ -8,6 +8,7 @@
 @bold: #c5c8c6;
 @admin: #f00000;
 @mod: @link;
+@echo: blue;
 @red: @admin;
 @blue: #57e8ed;
 @wood: rgba(40, 25, 20, 0.8);

--- a/less/tea.less
+++ b/less/tea.less
@@ -8,6 +8,7 @@
 @bold: #1a8522;
 @admin: #d60000;
 @mod: #7800b3;
+@echo: blue;
 @red: @admin;
 @blue: #1048ff;
 

--- a/less/win95.less
+++ b/less/win95.less
@@ -8,6 +8,7 @@
 @em: green;
 @del: @body;
 @mod: @blue;
+@echo: blue;
 @red: #dc143c;
 @gray: #c0c0c0;
 @blue: #0000aa;


### PR DESCRIPTION
Fixes #826
I also changed the place `italic` was in `common/index.ts` to match all the other lists.
As well as `successive_newlines` -> `successiveNewlines`, since vscode complained. (uh, it might be go lint but whatever)