### PR TITLE
client, server: Fix YouTube livestream embed

### DIFF
--- a/client/posts/embed.ts
+++ b/client/posts/embed.ts
@@ -75,56 +75,40 @@ async function fetchYouTube(el: Element): Promise<void> {
 		res = await fetch(`/api/youtube-data/${id}`),
 		[title, thumb, video, videoHigh] = (await res.text()).split("\n")
 
-	switch (res.status) {
-		case 200:
-			el.textContent = format(title, provider.YouTube)
-			break
-		case 415:
-			el.textContent = format("Error 415: YouTube video is a livestream", provider.YouTube)
-			el.classList.add("erred")
-			return
-		case 500:
-			el.textContent = format("Error 500: YouTube is not available", provider.YouTube)
-			el.classList.add("erred")
-			return
-		default:
-			const errmsg = `Error ${res.status}: ${res.statusText}`
-			el.textContent = format(errmsg, provider.YouTube)
-			el.classList.add("erred")
-			console.error(errmsg)
-			return
+	if (res.status != 200) {
+		return fetchNoEmbed(provider.YouTube)(el)
 	}
-
+	
 	if (!title) {
 		el.textContent = format("Error: Title does not exist", provider.YouTube)
 		el.classList.add("erred")
 		return
 	}
-
+	
 	if (!thumb) {
 		el.textContent = format("Error: Thumbnail does not exist", provider.YouTube)
 		el.classList.add("erred")
 		return
 	}
-
+	
 	if (!video) {
 		el.textContent = format("Error: Empty googlevideo URL", provider.YouTube)
 		el.classList.add("erred")
 		return
 	}
-
+	
 	if (!videoHigh) {
 		el.textContent = format("Error: Empty googlevideo (high res) URL", provider.YouTube)
 		el.classList.add("erred")
 		return
 	}
 
+	el.textContent = format(title, provider.YouTube)
 	el.setAttribute("data-html", encodeURIComponent(
-		`<video width="480" height="270" poster="`
-		+ thumb + `" ` + (ref.includes("loop=1") ? "loop " : '')
-		+ `controls><source src="` + video
-		+ (!ref.includes(`t=`) ? check("start") : '') + check("t")
-		+ `" type="video/webm">Your browser does not support the video tag.</video>`
+		`<video width="480" height="270" poster="${thumb}" `
+		+ (ref.includes("loop=1") ? "loop " : '') + `controls><source src="${video}`
+		+ (!ref.includes(`t=`) ? check("start") : '') + check("t") + `" type="`
+		+ (video.includes("mime=video%2Fwebm") ? "video/webm" : "video/mp4") + `"/>`
 	))
 
 	function check(s: string): string {

--- a/client/posts/posting/fullscreen.ts
+++ b/client/posts/posting/fullscreen.ts
@@ -11,16 +11,18 @@ function onFullscreen(e: Event) {
             e.stopPropagation()
             e.preventDefault()
 
+            const source = el.querySelector("source")
+
             if (
                 el.hasAttribute("src") ||
                 el.hasAttribute("HQ") ||
-                !el.querySelector("source").getAttribute("src").includes("googlevideo")
+                !source.getAttribute("src").includes("googlevideo")
             ) {
                 return
             }
 
-            const res = await fetch("/api/youtube-data/" +
-                el.getAttribute("poster").split("vi/").pop().split('/').shift()),
+            const res = await fetch("/api/youtube-data/"
+            + el.getAttribute("poster").split("vi/").pop().split('/').shift()),
             video = (await res.text()).split("\n").pop(),
             oldTime = el.currentTime
 
@@ -43,11 +45,13 @@ function onFullscreen(e: Event) {
                 return
             }
 
-            if (video.includes("mime=video%2Fmp4")) {
-                el.querySelector("source").setAttribute("type", "video/mp4")
+            if (video.includes("mime=video%2Fwebm")) {
+                source.setAttribute("type", "video/webm")
+            } else {
+                source.setAttribute("type", "video/mp4")
             }
 
-            el.querySelector("source").setAttribute("src", video)
+            source.setAttribute("src", video)
             el.setAttribute("HQ", true)
             el.load()
             el.currentTime = oldTime

--- a/go/src/meguca/server/embed.go
+++ b/go/src/meguca/server/embed.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"errors"
 	"strings"
 	"net/http"
 
@@ -12,133 +11,19 @@ import (
 	"github.com/badoux/goscraper"
 )
 
-// Get YouTube title and googlevideo URL from URL
+// Get YouTube video information by ID
 func youTubeData(w http.ResponseWriter, r *http.Request) {
-	ytid := extractParam(r, "id")
-	code, err := func() (code uint16, err error) {
-		code = 500
-		info, err := ytdl.GetVideoInfoFromID(ytid)
-
-		if err != nil {
-			return
-		} else if info.Duration == 0 {
-			return errYouTubeLive(ytid)
-		}
-
-		vidFormats := info.Formats.
-			Filter(ytdl.FormatExtensionKey, []interface{}{"webm"}).
-			Filter(ytdl.FormatResolutionKey, []interface{}{"360p"}).
-			Filter(ytdl.FormatAudioEncodingKey, []interface{}{"aac", "opus", "vorbis"}).
-			Best(ytdl.FormatVideoEncodingKey)
-			
-		if len(vidFormats) == 0 {
-			vidFormats = info.Formats.
-				Filter(ytdl.FormatExtensionKey, []interface{}{"webm"}).
-				Filter(ytdl.FormatResolutionKey, []interface{}{"144p", "240p", "270p", "360p"}).
-				Filter(ytdl.FormatAudioEncodingKey, []interface{}{"aac", "opus", "vorbis"}).
-				Best(ytdl.FormatResolutionKey).
-				Best(ytdl.FormatVideoEncodingKey)
-
-			if len(vidFormats) == 0 {
-				vidFormats = info.Formats.
-					Filter(ytdl.FormatExtensionKey, []interface{}{"mp4", "flv", "3gp", "ts"}).
-					Filter(ytdl.FormatResolutionKey, []interface{}{"144p", "240p", "270p", "360p"}).
-					Filter(ytdl.FormatAudioEncodingKey, []interface{}{"aac", "opus", "vorbis"}).
-					Best(ytdl.FormatResolutionKey).
-					Best(ytdl.FormatVideoEncodingKey)
-				
-				if len(vidFormats) == 0 {
-					return errNoYoutubeVideo(ytid)
-				}
-			}
-		}
-
-		video, err := info.GetDownloadURL(vidFormats[0])
-
-		if err != nil {
-			return
-		}
-
-		// Unfortunately, in some cases you cannot get 720p with only webm
-		vidFormats = info.Formats.
-			Filter(ytdl.FormatAudioEncodingKey, []interface{}{"aac", "opus", "vorbis"}).
-			Best(ytdl.FormatResolutionKey)
-
-		if len(vidFormats) == 0 {
-			return errNoYoutubeVideo(ytid)
-		}
-
-		videoHigh, err := info.GetDownloadURL(vidFormats[0])
-
-		if err != nil {
-			return
-		}
-
-		thumb := info.GetThumbnailURL(ytdl.ThumbnailQualityMaxRes)
-
-		for i := 0; i < 5; i++ {
-			ok, err := func() (bool, error) {
-				// Perhaps there is a way to check the status code without fetching the body?
-				resp, err := http.Get(thumb.String())
-
-				if err != nil {
-					return false, err
-				}
-
-				defer resp.Body.Close()
-
-				if resp.StatusCode == http.StatusOK {
-					return true, err
-				}
-
-				return false, err
-			}()
-
-			if err != nil {
-				return errNoYoutubeThumb(ytid)
-			}
-
-			if !ok {
-				switch i {
-				case 0:
-					thumb = info.GetThumbnailURL(ytdl.ThumbnailQualityHigh)
-				case 1:
-					thumb = info.GetThumbnailURL(ytdl.ThumbnailQualityMedium)
-				case 2:
-					thumb = info.GetThumbnailURL(ytdl.ThumbnailQualityDefault)
-				case 3:
-					thumb = info.GetThumbnailURL(ytdl.ThumbnailQualitySD)
-				default:
-					return errNoYoutubeThumb(ytid)
-				}
-			} else {
-				break
-			}
-		}
-
-		fmt.Fprintf(w, "%s\n%s\n%s\n%s",
-			info.Title,
-			strings.Replace(thumb.String(), "http://", "https://", 1),
-			video.String(),
-			videoHigh.String(),
-		)
-
-		return 200, nil
-	}()
+	info, err := getYouTubeInfo(extractParam(r, "id"))
 
 	if err != nil {
-		if !common.CanIgnoreClientError(err) {
-			err = common.StatusError{
-				fmt.Errorf("YouTube fetch error on ID `%s` %s", ytid, err),
-				int(code),
-			}
-		}
-
 		httpError(w, r, err)
+		return
 	}
+
+	w.Write([]byte(info))
 }
 
-// Get BitChute title from ID
+// Get BitChute video title by ID
 func bitChuteTitle(w http.ResponseWriter, r *http.Request) {
 	s, err := goscraper.Scrape("https://www.bitchute.com/embed/" + extractParam(r, "id"), 3)
 
@@ -150,14 +35,117 @@ func bitChuteTitle(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(s.Preview.Description))
 }
 
-func errYouTubeLive(id string) (uint16, error) {
-	return 415, common.StatusError{errors.New("YouTube video [" + id + "] is a livestream"), 415}
+// Return YouTube video info and handle errors
+func getYouTubeInfo(id string) (ret string, err error) {
+	var ok bool
+	info, err := ytdl.GetVideoInfoFromID(id)
+
+	if err != nil {
+		return ret, errYouTube(id, err)
+	} else if info.Duration == 0 {
+		return ret, errYouTubeLive(id)
+	}
+
+	thumb := info.GetThumbnailURL(ytdl.ThumbnailQualityMaxRes)
+
+	for _, val := range [4]ytdl.ThumbnailQuality {
+		ytdl.ThumbnailQualityHigh,
+		ytdl.ThumbnailQualityMedium,
+		ytdl.ThumbnailQualityDefault,
+		ytdl.ThumbnailQualitySD,
+	} {
+		resp, err := http.Get(thumb.String())
+		resp.Body.Close()
+
+		if err == nil {
+			if resp.StatusCode == http.StatusOK {
+				ok = true
+				break
+			}
+		}
+
+		thumb = info.GetThumbnailURL(val)
+	}
+
+	if !ok {
+		return ret, errNoYoutubeThumb(id)
+	}
+
+	vidFormats := info.Formats.
+		Filter(ytdl.FormatExtensionKey, []interface{}{"webm"}).
+		Filter(ytdl.FormatResolutionKey, []interface{}{"360p"}).
+		Filter(ytdl.FormatAudioEncodingKey, []interface{}{"aac", "opus", "vorbis"}).
+		Best(ytdl.FormatVideoEncodingKey)
+		
+	if len(vidFormats) == 0 {
+		vidFormats = info.Formats.
+			Filter(ytdl.FormatExtensionKey, []interface{}{"webm"}).
+			Filter(ytdl.FormatResolutionKey, []interface{}{"144p", "240p", "270p", "360p"}).
+			Filter(ytdl.FormatAudioEncodingKey, []interface{}{"aac", "opus", "vorbis"}).
+			Best(ytdl.FormatResolutionKey).
+			Best(ytdl.FormatVideoEncodingKey)
+
+		if len(vidFormats) == 0 {
+			vidFormats = info.Formats.
+				Filter(ytdl.FormatExtensionKey, []interface{}{"mp4", "flv", "3gp", "ts"}).
+				Filter(ytdl.FormatResolutionKey, []interface{}{"144p", "240p", "270p", "360p"}).
+				Filter(ytdl.FormatAudioEncodingKey, []interface{}{"aac", "opus", "vorbis"}).
+				Best(ytdl.FormatResolutionKey).
+				Best(ytdl.FormatVideoEncodingKey)
+			
+			if len(vidFormats) == 0 {
+				return ret, errNoYoutubeVideo(id)
+			}
+		}
+	}
+
+	video, err := info.GetDownloadURL(vidFormats[0])
+
+	if err != nil {
+		return ret, errYouTube(id, err)
+	}
+
+	// Unfortunately, in some cases you cannot get 720p with only webm
+	vidFormats = info.Formats.
+		Filter(ytdl.FormatAudioEncodingKey, []interface{}{"aac", "opus", "vorbis"}).
+		Best(ytdl.FormatResolutionKey).
+		Best(ytdl.FormatVideoEncodingKey)
+
+	if len(vidFormats) == 0 {
+		return ret, errNoYoutubeVideo(id)
+	}
+
+	videoHigh, err := info.GetDownloadURL(vidFormats[0])
+
+	if err != nil {
+		return ret, errYouTube(id, err)
+	}
+
+	return fmt.Sprintf(
+		"%s\n%s\n%s\n%s",
+		info.Title,
+		strings.Replace(thumb.String(), "http://", "https://", 1),
+		video.String(),
+		videoHigh.String(),
+	), nil
 }
 
-func errNoYoutubeVideo(id string) (uint16, error) {
-	return 404, common.StatusError{errors.New("YouTube video [" + id + "] does not exist"), 404}
+func errYouTube(id string, err error) error {
+	return errYouTubeGeneric(id, err.Error(), 500)
 }
 
-func errNoYoutubeThumb(id string) (uint16, error) {
-	return 404, common.StatusError{errors.New("YouTube thumbnail [" + id + "] does not exist"), 404}
+func errYouTubeLive(id string) error {
+	return errYouTubeGeneric(id, "Video is a livestream", 415)
+}
+
+func errNoYoutubeVideo(id string) error {
+	return errYouTubeGeneric(id, "Video does not exist", 404)
+}
+
+func errNoYoutubeThumb(id string) error {
+	return errYouTubeGeneric(id, "Thumbnail does not exist", 404)
+}
+
+func errYouTubeGeneric(id string, err string, code int) error {
+	return common.StatusError{fmt.Errorf("YouTube [%s]: %s", id, err), code}
 }


### PR DESCRIPTION
Fixes #809
Don't merge yet, we need to figure out how we're going to get the actual playing to work.
Unfortunately, it seems that livestreaming isn't standardized yet as far as browsers go, and we'll need for a player for this specific instance.
So far, I'm looking at this: https://github.com/video-dev/hls.js
Now, the problem is, I don't know the best way to work this into meguca's workflow.
If we put it into `package.json` somehow, I think it would go into `www/vendor`, right?
What would you do?