### PR TITLE
client, templates: Round time properly

### DIFF
--- a/client/util/time.ts
+++ b/client/util/time.ts
@@ -5,15 +5,15 @@ import { pluralize } from "."
 export function secondsToTime(s: number): string {
     const divide = [60, 24, 30, 12],
     unit = ['minute', 'hour', 'day', 'month']
-    let time = Math.floor(s) / 60
+    let time = Math.round(s) / 60
 
     for (let i = 0; i < divide.length; i++) {
         if (time < divide[i]) {
-            return pluralize(Math.round(time * 1e0), lang.plurals[unit[i]])
+            return pluralize(parseInt(time.toFixed(0), 10), lang.plurals[unit[i]])
         }
 
-        time = Math.floor(time / divide[i])
+        time = Math.round(time / divide[i])
     }
 
-    return pluralize(Math.round(time * 1e0), lang.plurals["year"])
+    return pluralize(parseInt(time.toFixed(0), 10), lang.plurals["year"])
 }

--- a/go/src/meguca/templates/article.go
+++ b/go/src/meguca/templates/article.go
@@ -178,16 +178,16 @@ func parseModLog(p common.Post) (bool, string) {
 
 // Returns human readable time
 func secondsToTime(s float64) string {
-	time := math.Floor(s) / 60
 	divide := [4]float64{60, 24, 30, 12}
 	unit := [4]string{"minute", "hour", "day", "month"}
+	time := math.Round(s) / 60
 
 	for i := 0; i < len(divide); i++ {
 		if time < divide[i] {
 			return pluralize(int(toFixed(time, 0)), unit[i])
 		}
 
-		time = math.Floor(time / divide[i])
+		time = math.Round(time / divide[i])
 	}
 
 	return pluralize(int(toFixed(time, 0)), "year")


### PR DESCRIPTION
Fixes the incorrect ban times.
It is rounding, so if you do 4 hours and 29 minutes, you will get 4 hours, and 5 hours with 4 hours and 31 minutes. 4 hours and 30 minutes (in the field) will result in 4 hours, because by it is actually 4 hours, 29 minutes and 59 seconds.