### PR TITLE
client: More usable quoting and pasting

### DIFF
--- a/client/posts/posting/model.ts
+++ b/client/posts/posting/model.ts
@@ -174,9 +174,8 @@ export default class FormModel extends Post {
 		switch (old.charAt(pos)) {
 		case '':
 		case ' ':
-			s += sel ? '\n' : ''
-			break
 		case '\n':
+			s += sel ? '\n' : ''
 			break
 		default:
 			b = true

--- a/client/posts/posting/paste.ts
+++ b/client/posts/posting/paste.ts
@@ -1,43 +1,78 @@
-// File upload via clipboard paste
-
+// File upload or text alteration via clipboard paste
 import { postSM, postEvent } from ".";
-import { trigger } from "../../util";
+import { trigger, modPaste } from "../../util";
 import { page, boardConfig } from "../../state";
 import FormModel from "./model";
 import { expandThreadForm } from "./threads";
 
-// Handle file paste
+// Handle file or text paste
 function onPaste(e: ClipboardEvent) {
-	const { files } = e.clipboardData;
-	if (files.length !== 1) {
-		return;
+	const text = e.clipboardData.getData("text"),
+	files = e.clipboardData.files
+	var threadForm: HTMLFormElement,
+	m: FormModel
+
+	if (!text && files.length !== 1) {
+		return
 	}
 
-	e.stopPropagation();
-	e.preventDefault();
-
-	if (boardConfig.textOnly) {
-		return;
-	}
+	e.stopPropagation()
+	e.preventDefault()
 
 	if (!page.thread) {
-		expandThreadForm();
-		(document
-			.querySelector("#new-thread-form input[type=file]") as any)
-			.files = files;
-		return;
+		expandThreadForm()
+		threadForm = document.querySelector("#new-thread-form") as HTMLFormElement
+	} else {
+		// Create form, if none
+		postSM.feed(postEvent.open)
+		// Neither disconnected, errored or already has image
+		m = trigger("getPostModel") as FormModel
 	}
 
-	// Create form, if none
-	postSM.feed(postEvent.open);
+	if (text) {
+		if (threadForm) {
+			const area = threadForm.querySelector("textarea[name=body]") as HTMLTextAreaElement,
+			start = area.selectionStart,
+			end = area.selectionEnd,
+			old = area.value
+			let p = modPaste(old, text, end)
 
-	// Neither disconnected, erred or already has image
-	const m = trigger("getPostModel") as FormModel;
-	if (m) {
-		m.uploadFile(files[0]);
+			if (!p) {
+				return
+			}
+
+			if (start != end) {
+				area.value = old.slice(0, start) + p.body + old.slice(end)
+				p.pos -= start
+			} else {
+				area.value = old.slice(0, end) + p.body + old.slice(end)
+			}
+
+			area.setSelectionRange(p.pos, p.pos)
+			area.focus()
+			return
+		}
+
+		if (m) {
+			m.paste(text)
+		}
+	}
+
+	if (files.length === 1) {
+		if (boardConfig.textOnly) {
+			return
+		}
+
+		if (threadForm) {
+			(threadForm.querySelector("input[type=file]") as any).files = files
+			return
+		}
+
+		if (m) {
+			m.uploadFile(files.item(0))
+		}
 	}
 }
 
 // Bind listeners
-export default () =>
-	document.addEventListener("paste", onPaste);
+export default () => document.addEventListener("paste", onPaste)

--- a/client/posts/posting/view.ts
+++ b/client/posts/posting/view.ts
@@ -147,17 +147,19 @@ export default class FormView extends PostView {
 
     // Replace the current body and set the cursor to the input's end.
     // commit sets, if the onInput method should be run.
-    public replaceText(body: string, commit: boolean) {
+    public replaceText(body: string, pos: number, commit: boolean) {
         const el = this.input
         el.value = body
+
         if (commit) {
             this.onInput()
         } else {
             this.resizeInput()
         }
+
         requestAnimationFrame(() => {
             el.focus()
-            el.setSelectionRange(body.length, body.length)
+            el.setSelectionRange(pos, pos)
 
             // Because Firefox refocuses the clicked <a>
             requestAnimationFrame(() =>

--- a/client/util/index.ts
+++ b/client/util/index.ts
@@ -12,6 +12,11 @@ export interface OnOptions extends EventListenerOptions {
 	selector?: string
 }
 
+export interface Paste {
+	body: string
+	pos: number
+}
+
 // Any object with an event-based interface for passing to load()
 interface Loader {
 	onload: EventListener
@@ -197,4 +202,42 @@ export function extractJSON(id: string): any {
 		return null
 	}
 	return JSON.parse(el.textContent)
+}
+
+// Returns modified paste which quotes all following lines
+// if first line is quoted, and new cursor position
+export function modPaste(old: string, sel: string, pos: number): Paste {
+	let s = '',
+	b = false
+
+	if (!sel) {
+		return
+	}
+
+	if (sel.charAt(0) == '>') {
+		switch (old.charAt(pos - 1)) {
+		case '':
+		case '\n':
+			break
+		default:
+			s = '\n'
+		}
+
+		for (let line of sel.split('\n')) {
+			s += `>${line}\n`
+		}
+
+		switch (old.charAt(pos)) {
+		case '':
+		case '\n':
+			break
+		default:
+			b = true
+			s += '\n'
+		}
+	} else {
+		s += sel
+	}
+
+	return {body: s, pos: b ? pos + s.length - 1 : pos + s.length}
 }


### PR DESCRIPTION
Fixes #435 
Fixes #600
I chose to not make a newline if the post form is opened by clicking an ID, because you may want to do ">>324532 >>324533 >>324534", etc.
From what I can tell from the testing, this is a nice little QoL improvement.