### PR TITLE
js: Use version number for whatwg-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meguca",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1915,7 +1915,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "1.0.2",
@@ -4317,7 +4317,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "when": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meguca",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "AGPL-3.0",
   "main": "www/js/main.js",
   "repository": {
@@ -24,6 +24,6 @@
     "gulp-util": "latest",
     "typescript": "latest",
     "uglify-js": "latest",
-    "whatwg-fetch": "latest"
+    "whatwg-fetch": "^2.0.4"
   }
 }


### PR DESCRIPTION
Reasoning:
```
cp node_modules/dom4/build/dom4.js node_modules/core-js/client/core.min.js node_modules/core-js/client/core.min.js.map www/js/vendor
/home/okina/go/src/github.com/bakape/meguca/node_modules/.bin/uglifyjs node_modules/whatwg-fetch/fetch.js -o www/js/vendor/fetch.js
Parse error at node_modules/whatwg-fetch/fetch.js:78,7
export function Headers(headers) {
       ^
ERROR: Unexpected token: keyword (function)
    at JS_Parse_Error.get (eval at <anonymous> (/home/okina/go/src/github.com/bakape/meguca/node_modules/uglify-js/tools/node.js:20:1), <anonymous>:71:23)
    at fatal (/home/okina/go/src/github.com/bakape/meguca/node_modules/uglify-js/bin/uglifyjs:291:53)
    at run (/home/okina/go/src/github.com/bakape/meguca/node_modules/uglify-js/bin/uglifyjs:235:9)
    at Object.<anonymous> (/home/okina/go/src/github.com/bakape/meguca/node_modules/uglify-js/bin/uglifyjs:160:5)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
make: *** [Makefile:52: client_vendor] Error 1
```
If this happens again, I'll just revert the package.json changes from a13e83ab7e439ff98039dafbb4115d5254033121 and update the version.