### PR TITLE
common: Ignore weird YouTube error

### DIFF
--- a/server/src/meguca/common/errors.go
+++ b/server/src/meguca/common/errors.go
@@ -112,6 +112,7 @@ recheck:
 		"Error extracting sts from embedded url response",
 		"Error parsing signature tokens",
 		"\": invalid syntax",
+		"Error %!d(string=150)",
 	} {
 		if strings.HasSuffix(s, suff) {
 			return true


### PR DESCRIPTION
Fixes #941
If there's another one, I think it may be prudent to just ignore all YouTube errors, at least keep them from sending mail.