### PR TITLE
Make thumbnails display:block.

### DIFF
--- a/less/posts.mix.less
+++ b/less/posts.mix.less
@@ -108,6 +108,7 @@ figure {
 		display: block;
 	}
 	img {
+		display: block;
 		border: 0;
 	}
 }


### PR DESCRIPTION
There is a small amount of space that gets added to the height of thumbnails (specfically the &lt;a&gt; element) which I think is caused by the browser trying to make the height a multiple of the line-height. Making the &lt;img&gt; a block element seems to solve this.
Here is a screenshot showing this (taken using the Screenshot Node feature in firefox dev tools)
![Screen Shot 2019-10-30 at 15 16 03](https://user-images.githubusercontent.com/8852840/67831257-c5157d80-fb31-11e9-9296-4319f2ed9546.png)
You can also see it when you select the thumbnail and the dotted outline appears around it showing the extra space at the bottom.