### PR TITLE
fix eden banner dj detection

### DIFF
--- a/client/options/nowPlaying.ts
+++ b/client/options/nowPlaying.ts
@@ -44,8 +44,10 @@ function edenData(res: any): RadioData {
 		listeners: {
 			current: listeners,
 		},
+		live: {
+			streamer_name: dj,
+		},
 		now_playing: {
-			streamer: dj,
 			song: {
 				text: np,
 			},


### PR DESCRIPTION
now_playing.streamer only updates when a song begins. Use
live.streamer_name instead.