### PR TITLE
deps, docker, make: install extra flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ imager/images
 db.db
 easyjson-bootstrap*.go
 GeoLite2-Country.mmdb
+dbip-city-lite.mmdb
 *.wasm
 *.wast
 *.map

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y \
 	libwebp-dev \
 	libopencv-dev \
 	libgeoip-dev \
-	git lsb-release wget curl netcat postgresql-client
+	git lsb-release wget curl netcat postgresql-client gunzip
 RUN apt-get dist-upgrade -y
 
 # Install Node.js
@@ -39,4 +39,8 @@ COPY docs/config.json .
 RUN sed -i 's/localhost:5432/postgres:5432/' config.json
 RUN sed -i 's/"reverse_proxied": false/"reverse_proxied": true/' config.json
 RUN sed -i 's/127\.0\.0\.1:8000/:8000/' config.json
+
+# Install extra shitposting flags
+RUN set -o pipefail && curl https://download.db-ip.com/free/dbip-city-lite-2020-08.mmdb.gz | gunzip > dbip-city-lite.mmdb
+
 RUN make

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ generate:
 	go generate ./...
 
 server:
-	curl https://download.db-ip.com/free/dbip-city-lite-2020-08.mmdb.gz | gunzip > dbip-city-lite.mmdb
 	go build -v
 
 client_clean:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ All commands assume to be run by the root user.
 ```bash
 # Install OS dependencies
 apt update
-apt-get install -y build-essential pkg-config libpth-dev libavcodec-dev libavutil-dev libavformat-dev libswscale-dev libwebp-dev libopencv-dev libgeoip-dev git lsb-release wget curl sudo postgresql
+apt-get install -y build-essential pkg-config libpth-dev libavcodec-dev libavutil-dev libavformat-dev libswscale-dev libwebp-dev libopencv-dev libgeoip-dev git lsb-release wget curl sudo postgresql gunzip
 apt-get dist-upgrade -y
 
 # Increase PostgreSQL connection limit by changing `max_connections` to 1024
@@ -30,9 +30,14 @@ source /etc/profile
 wget -qO- https://deb.nodesource.com/setup_10.x | bash -
 apt-get install -y nodejs
 
-# Clone and build meguca
+# Clone meguca
 git clone -b v6 https://github.com/bakape/meguca.git meguca
 cd meguca
+
+# Install extra shitposting flags
+curl https://download.db-ip.com/free/dbip-city-lite-2020-08.mmdb.gz | gunzip > dbip-city-lite.mmdb
+
+# Build meguca
 make
 
 # Edit instance configs


### PR DESCRIPTION
Because downloading a ~90MB file every time you run ``make`` is not ideal.
Full disclaimer, I have not tested the docker change, but it's probably fine.