### PR TITLE
gallery mode: don't hide the post anchor

### DIFF
--- a/client/options/specs.ts
+++ b/client/options/specs.ts
@@ -257,8 +257,13 @@ export const specs: { [id: string]: OptionSpec } = {
 			.fileinfo,
 			blockquote,
 			.backlinks,
-			header {
+			header > :not(nav),
+			header .quote,
+			header .mod-checkbox {
 				display: none;
+			}
+			header, figcaption {
+				display: inline-block;
 			}
 			#thread-container, article:not(.reply-form) {
 				display: inline-table;
@@ -279,8 +284,12 @@ export const specs: { [id: string]: OptionSpec } = {
 				padding: 0.5em;
 				width: fit-content;
 			}
-			a[download] {
+			a[download], header nav {
 				font-size: 0;
+			}
+			header nav a:first-child::before {
+				content: "# ";
+				font-size: 15px;
 			}
 			a[download]::before {
 				content: " 🡇";


### PR DESCRIPTION
Keeps the anchor link in gallery mode so one can mark and jump back to a specific post when leaving gallery mode