### PR TITLE
client: fix rare load issue

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -85,7 +85,7 @@ async function start() {
 			const id = parseInt(addMine);
 			storeMine(id, id);
 			storeSeenPost(id, id);
-			watchThread(id, 1, 0, page.board, thread.subject);
+			await watchThread(id, 1, 0, page.board, thread.subject);
 			deleteCookie("addMine");
 		}
 	} else {

--- a/client/page/thread_watcher.ts
+++ b/client/page/thread_watcher.ts
@@ -323,7 +323,9 @@ export async function watchThread(id: number, postCount: number,
 
 	await putExpiring("watchedThreads", id, data);
 
-	watcherPanel.addRow(data);
+	if (watcherPanel) {
+		watcherPanel.addRow(data);
+	}
 	propagateWatch(data);
 }
 


### PR DESCRIPTION
The ``watchThread`` call in ``main.ts`` tried to use the ``watcherPanel`` while it's still null, which would error and stop the page loading.