### PR TITLE
Fix default audio volume slider

### DIFF
--- a/client/ui/options.ts
+++ b/client/ui/options.ts
@@ -64,8 +64,10 @@ export default class OptionsPanel extends TabbedModal {
 				el.checked = val as boolean
 				break
 			case optionType.number:
-			case optionType.menu:
 			case optionType.range:
+				el.valueAsNumber = val as number
+				break
+			case optionType.menu:
 			case optionType.textarea:
 				el.value = val as string || ""
 				break


### PR DESCRIPTION
`assignValue` incorrectly assumes the value passed is a string for number and range options. This is a problem when the value is zero since assigning an empty string will reset the option to the default.