### PR TITLE
Remove deploy-specific URL rewriting in redirect handler

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -141,7 +141,7 @@ export default () => {
 			m.applyModeration(msg))
 
 	handlers[message.redirect] = (url: string) =>
-		location.href = url.replace(/shamik\.ooo|megu\.ca/, location.hostname) || url
+		location.href = url
 
 	handlers[message.notification] = (text: string) =>
 		new OverlayNotification(text)


### PR DESCRIPTION
There is no need to rewrite the URL in the redirect handler because Window.location supports relative URLs.
e.g. `location.href = "/a/catalog"` will keep the origin hostname.