### PR TITLE
Clean up SameSite cookie changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Documentation for this file is available under `docs/config.jsonc`.
 It is recommended to serve meguca behind a reverse proxy like NGINX or Apache
 with properly configured TLS settings. A sample NGINX configuration file can be
 found in `docs/`.
-Meguca needs to use HTTPS to work outside of localhost.
 
 ### Initial instance configuration
 

--- a/auth/captcha.go
+++ b/auth/captcha.go
@@ -80,12 +80,16 @@ func (b *Base64Token) EnsureCookie(
 			return
 		}
 
-		util.SetCookie(w, r, &http.Cookie{
+		err = util.SetCookie(w, r, &http.Cookie{
 			Name:    CaptchaCookie,
 			Value:   string(text),
 			Path:    "/",
 			Expires: time.Now().Add(time.Hour * 24),
 		})
+		if err != nil {
+			return
+		}
+
 		return
 	default:
 		return fmt.Errorf("auth: reading cookie: %s", err)

--- a/auth/captcha.go
+++ b/auth/captcha.go
@@ -14,7 +14,6 @@ import (
 	captchouli_common "github.com/bakape/captchouli/v2/common"
 	"github.com/bakape/meguca/common"
 	"github.com/bakape/meguca/config"
-	"github.com/bakape/meguca/util"
 )
 
 const (
@@ -80,16 +79,14 @@ func (b *Base64Token) EnsureCookie(
 			return
 		}
 
-		err = util.SetCookie(w, r, &http.Cookie{
-			Name:    CaptchaCookie,
-			Value:   string(text),
-			Path:    "/",
-			Expires: time.Now().Add(time.Hour * 24),
+		http.SetCookie(w, &http.Cookie{
+			Name:     CaptchaCookie,
+			Value:    string(text),
+			Path:     "/",
+			Expires:  time.Now().Add(time.Hour * 24),
+			Secure:   true,
+			SameSite: http.SameSiteNoneMode,
 		})
-		if err != nil {
-			return
-		}
-
 		return
 	default:
 		return fmt.Errorf("auth: reading cookie: %s", err)

--- a/auth/captcha.go
+++ b/auth/captcha.go
@@ -80,10 +80,11 @@ func (b *Base64Token) EnsureCookie(
 		}
 
 		http.SetCookie(w, &http.Cookie{
-			Name:    CaptchaCookie,
-			Value:   string(text),
-			Path:    "/",
-			Expires: time.Now().Add(time.Hour * 24),
+			Name:     CaptchaCookie,
+			Value:    string(text),
+			Path:     "/",
+			Expires:  time.Now().Add(time.Hour * 24),
+			SameSite: http.SameSiteStrictMode,
 		})
 		return
 	default:

--- a/auth/captcha.go
+++ b/auth/captcha.go
@@ -80,12 +80,10 @@ func (b *Base64Token) EnsureCookie(
 		}
 
 		http.SetCookie(w, &http.Cookie{
-			Name:     CaptchaCookie,
-			Value:    string(text),
-			Path:     "/",
-			Expires:  time.Now().Add(time.Hour * 24),
-			Secure:   true,
-			SameSite: http.SameSiteNoneMode,
+			Name:    CaptchaCookie,
+			Value:   string(text),
+			Path:    "/",
+			Expires: time.Now().Add(time.Hour * 24),
 		})
 		return
 	default:

--- a/client/options/specs.ts
+++ b/client/options/specs.ts
@@ -170,7 +170,9 @@ export const specs: { [id: string]: OptionSpec } = {
 			document
 				.getElementById('theme-css')
 				.setAttribute('href', `/assets/css/${theme}.css`)
-			setCookie("theme", theme, 365 * 10)
+			// The server needs the theme cookie when nagivating from
+			// a third party website, so we set SameSite=Lax.
+			setCookie("theme", theme, 365 * 10, "lax")
 		},
 	},
 	// Custom user-set background
@@ -348,7 +350,7 @@ function overrideSet(key: string, flag: number): () => void {
 		let store = document.getElementById(key) as HTMLInputElement;
 		store.valueAsNumber = data ^ flag;
 		// Have to manually trigger change event
-		let evt = new Event("change", {bubbles: true});
+		let evt = new Event("change", { bubbles: true });
 		store.dispatchEvent(evt);
 	}
 }

--- a/client/util/index.ts
+++ b/client/util/index.ts
@@ -176,7 +176,7 @@ export function inputElement(
 export function setCookie(key: string, val: string, days: number) {
 	let date = new Date()
 	date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000))
-	document.cookie = `${key}=${val}; expires=${date.toUTCString()}; path=/; samesite=none; secure;`;
+	document.cookie = `${key}=${val}; expires=${date.toUTCString()}; path=/;`;
 }
 
 // Get a cookie value by name. Returns empty string, if none.

--- a/client/util/index.ts
+++ b/client/util/index.ts
@@ -174,14 +174,12 @@ export function inputElement(
 
 // Returns string to add security options to cookie
 function secureCookie() {
-	let c = " samesite=Lax;";
 	for (let s of ["127.0.0.1", "[::1]", "localhost"]) {
 		if (location.hostname === s) {
-			return c
+			return "";
 		}
 	}
-	c += " secure;";
-	return c
+	return " samesite=none; secure;";
 }
 
 // Set a global cookie, that expires after `days`

--- a/client/util/index.ts
+++ b/client/util/index.ts
@@ -172,11 +172,13 @@ export function inputElement(
 	return parent.querySelector(`input[name="${name}"]`) as HTMLInputElement
 }
 
+type SameSiteValue = "none" | "lax" | "strict"
+
 // Set a global cookie, that expires after `days`
-export function setCookie(key: string, val: string, days: number) {
+export function setCookie(key: string, val: string, days: number, samesite: SameSiteValue = "strict") {
 	let date = new Date()
 	date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000))
-	document.cookie = `${key}=${val}; expires=${date.toUTCString()}; path=/;`;
+	document.cookie = `${key}=${val}; expires=${date.toUTCString()}; path=/; samesite=${samesite}`
 }
 
 // Get a cookie value by name. Returns empty string, if none.

--- a/client/util/index.ts
+++ b/client/util/index.ts
@@ -172,22 +172,11 @@ export function inputElement(
 	return parent.querySelector(`input[name="${name}"]`) as HTMLInputElement
 }
 
-// Returns string to add security options to cookie
-function secureCookie() {
-	for (let s of ["127.0.0.1", "[::1]", "localhost"]) {
-		if (location.hostname === s) {
-			return "";
-		}
-	}
-	return " samesite=none; secure;";
-}
-
 // Set a global cookie, that expires after `days`
 export function setCookie(key: string, val: string, days: number) {
-	let date = new Date();
-	date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-	document.cookie =
-		`${key}=${val}; expires=${date.toUTCString()}; path=/;${secureCookie}`;
+	let date = new Date()
+	date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000))
+	document.cookie = `${key}=${val}; expires=${date.toUTCString()}; path=/; samesite=none; secure;`;
 }
 
 // Get a cookie value by name. Returns empty string, if none.

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -102,16 +102,18 @@ func commitLogin(w http.ResponseWriter, ip, userID string) (err error) {
 	expires := time.Now().
 		Add(time.Duration(config.Get().SessionExpiry)*time.Hour*24 - time.Hour)
 	http.SetCookie(w, &http.Cookie{
-		Name:    "loginID",
-		Value:   url.QueryEscape(userID),
-		Path:    "/",
-		Expires: expires,
+		Name:     "loginID",
+		Value:    url.QueryEscape(userID),
+		Path:     "/",
+		Expires:  expires,
+		SameSite: http.SameSiteStrictMode,
 	})
 	http.SetCookie(w, &http.Cookie{
-		Name:    "session",
-		Value:   token,
-		Path:    "/",
-		Expires: expires,
+		Name:     "session",
+		Value:    token,
+		Path:     "/",
+		Expires:  expires,
+		SameSite: http.SameSiteStrictMode,
 	})
 	return
 }

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -102,20 +102,16 @@ func commitLogin(w http.ResponseWriter, ip, userID string) (err error) {
 	expires := time.Now().
 		Add(time.Duration(config.Get().SessionExpiry)*time.Hour*24 - time.Hour)
 	http.SetCookie(w, &http.Cookie{
-		Name:     "loginID",
-		Value:    url.QueryEscape(userID),
-		Path:     "/",
-		Expires:  expires,
-		Secure:   true,
-		SameSite: http.SameSiteNoneMode,
+		Name:    "loginID",
+		Value:   url.QueryEscape(userID),
+		Path:    "/",
+		Expires: expires,
 	})
 	http.SetCookie(w, &http.Cookie{
-		Name:     "session",
-		Value:    token,
-		Path:     "/",
-		Expires:  expires,
-		Secure:   true,
-		SameSite: http.SameSiteNoneMode,
+		Name:    "session",
+		Value:   token,
+		Path:    "/",
+		Expires: expires,
 	})
 	return
 }

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -106,18 +106,24 @@ func commitLogin(
 	// deleted
 	expires := time.Now().
 		Add(time.Duration(config.Get().SessionExpiry)*time.Hour*24 - time.Hour)
-	util.SetCookie(w, r, &http.Cookie{
+	err = util.SetCookie(w, r, &http.Cookie{
 		Name:    "loginID",
 		Value:   url.QueryEscape(userID),
 		Path:    "/",
 		Expires: expires,
 	})
-	util.SetCookie(w, r, &http.Cookie{
+	if err != nil {
+		return
+	}
+	err = util.SetCookie(w, r, &http.Cookie{
 		Name:    "session",
 		Value:   token,
 		Path:    "/",
 		Expires: expires,
 	})
+	if err != nil {
+		return
+	}
 	return
 }
 

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bakape/meguca/common"
 	"github.com/bakape/meguca/config"
 	"github.com/bakape/meguca/db"
-	"github.com/bakape/meguca/util"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -66,7 +65,7 @@ func register(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		return commitLogin(w, r, "", req.ID)
+		return commitLogin(w, "", req.ID)
 	}()
 	if err != nil {
 		httpError(w, r, err)
@@ -83,11 +82,7 @@ func validateUserID(w http.ResponseWriter, r *http.Request, id string) error {
 
 // If login successful, generate a session token and commit to DB. Otherwise
 // write error message to client.
-func commitLogin(
-	w http.ResponseWriter, r *http.Request, ip, userID string,
-) (
-	err error,
-) {
+func commitLogin(w http.ResponseWriter, ip, userID string) (err error) {
 	token, err := auth.RandomID(128)
 	if err != nil {
 		return
@@ -106,24 +101,22 @@ func commitLogin(
 	// deleted
 	expires := time.Now().
 		Add(time.Duration(config.Get().SessionExpiry)*time.Hour*24 - time.Hour)
-	err = util.SetCookie(w, r, &http.Cookie{
-		Name:    "loginID",
-		Value:   url.QueryEscape(userID),
-		Path:    "/",
-		Expires: expires,
+	http.SetCookie(w, &http.Cookie{
+		Name:     "loginID",
+		Value:    url.QueryEscape(userID),
+		Path:     "/",
+		Expires:  expires,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
 	})
-	if err != nil {
-		return
-	}
-	err = util.SetCookie(w, r, &http.Cookie{
-		Name:    "session",
-		Value:   token,
-		Path:    "/",
-		Expires: expires,
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    token,
+		Path:     "/",
+		Expires:  expires,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
 	})
-	if err != nil {
-		return
-	}
 	return
 }
 
@@ -179,7 +172,7 @@ func login(w http.ResponseWriter, r *http.Request) {
 		default:
 			return
 		}
-		return commitLogin(w, r, ip, req.ID)
+		return commitLogin(w, ip, req.ID)
 	}()
 	if err != nil {
 		httpError(w, r, err)

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -100,20 +100,16 @@ func TestIsLoggedIn(t *testing.T) {
 func setLoginCookies(r *http.Request, creds auth.SessionCreds) {
 	expires := time.Now().Add(time.Hour)
 	r.AddCookie(&http.Cookie{
-		Name:     "loginID",
-		Value:    creds.UserID,
-		Path:     "/",
-		Expires:  expires,
-		Secure:   true,
-		SameSite: http.SameSiteNoneMode,
+		Name:    "loginID",
+		Value:   creds.UserID,
+		Path:    "/",
+		Expires: expires,
 	})
 	r.AddCookie(&http.Cookie{
-		Name:     "session",
-		Value:    creds.Session,
-		Path:     "/",
-		Expires:  expires,
-		Secure:   true,
-		SameSite: http.SameSiteNoneMode,
+		Name:    "session",
+		Value:   creds.Session,
+		Path:    "/",
+		Expires: expires,
 	})
 }
 

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -100,16 +100,18 @@ func TestIsLoggedIn(t *testing.T) {
 func setLoginCookies(r *http.Request, creds auth.SessionCreds) {
 	expires := time.Now().Add(time.Hour)
 	r.AddCookie(&http.Cookie{
-		Name:    "loginID",
-		Value:   creds.UserID,
-		Path:    "/",
-		Expires: expires,
+		Name:     "loginID",
+		Value:    creds.UserID,
+		Path:     "/",
+		Expires:  expires,
+		SameSite: http.SameSiteStrictMode,
 	})
 	r.AddCookie(&http.Cookie{
-		Name:    "session",
-		Value:   creds.Session,
-		Path:    "/",
-		Expires: expires,
+		Name:     "session",
+		Value:    creds.Session,
+		Path:     "/",
+		Expires:  expires,
+		SameSite: http.SameSiteStrictMode,
 	})
 }
 

--- a/server/post_creation.go
+++ b/server/post_creation.go
@@ -43,11 +43,14 @@ func createThread(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Let the JS add the ID of the post to "mine"
-		util.SetCookie(w, r, &http.Cookie{
+		err = util.SetCookie(w, r, &http.Cookie{
 			Name:  "addMine",
 			Value: strconv.FormatUint(post.ID, 10),
 			Path:  "/",
 		})
+		if err != nil {
+			return
+		}
 
 		http.Redirect(w, r, fmt.Sprintf(`/%s/%d`, req.Board, post.ID), 303)
 		incrementSpamscore(ip, req.Body, session, true)

--- a/server/post_creation.go
+++ b/server/post_creation.go
@@ -43,9 +43,10 @@ func createThread(w http.ResponseWriter, r *http.Request) {
 
 		// Let the JS add the ID of the post to "mine"
 		http.SetCookie(w, &http.Cookie{
-			Name:  "addMine",
-			Value: strconv.FormatUint(post.ID, 10),
-			Path:  "/",
+			Name:     "addMine",
+			Value:    strconv.FormatUint(post.ID, 10),
+			Path:     "/",
+			SameSite: http.SameSiteStrictMode,
 		})
 
 		http.Redirect(w, r, fmt.Sprintf(`/%s/%d`, req.Board, post.ID), 303)

--- a/server/post_creation.go
+++ b/server/post_creation.go
@@ -15,7 +15,6 @@ import (
 	"github.com/bakape/meguca/config"
 	"github.com/bakape/meguca/db"
 	"github.com/bakape/meguca/imager"
-	"github.com/bakape/meguca/util"
 	"github.com/bakape/meguca/websockets"
 	"github.com/bakape/meguca/websockets/feeds"
 )
@@ -43,14 +42,13 @@ func createThread(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Let the JS add the ID of the post to "mine"
-		err = util.SetCookie(w, r, &http.Cookie{
-			Name:  "addMine",
-			Value: strconv.FormatUint(post.ID, 10),
-			Path:  "/",
+		http.SetCookie(w, &http.Cookie{
+			Name:     "addMine",
+			Value:    strconv.FormatUint(post.ID, 10),
+			Path:     "/",
+			Secure:   true,
+			SameSite: http.SameSiteNoneMode,
 		})
-		if err != nil {
-			return
-		}
 
 		http.Redirect(w, r, fmt.Sprintf(`/%s/%d`, req.Board, post.ID), 303)
 		incrementSpamscore(ip, req.Body, session, true)

--- a/server/post_creation.go
+++ b/server/post_creation.go
@@ -43,11 +43,9 @@ func createThread(w http.ResponseWriter, r *http.Request) {
 
 		// Let the JS add the ID of the post to "mine"
 		http.SetCookie(w, &http.Cookie{
-			Name:     "addMine",
-			Value:    strconv.FormatUint(post.ID, 10),
-			Path:     "/",
-			Secure:   true,
-			SameSite: http.SameSiteNoneMode,
+			Name:  "addMine",
+			Value: strconv.FormatUint(post.ID, 10),
+			Path:  "/",
 		})
 
 		http.Redirect(w, r, fmt.Sprintf(`/%s/%d`, req.Board, post.ID), 303)

--- a/util/util.go
+++ b/util/util.go
@@ -171,17 +171,21 @@ func TrimString(s *string, maxLen int) {
 }
 
 // Adds security options to cookie and sets it in responsewriter
-func SetCookie(w http.ResponseWriter, r *http.Request, c *http.Cookie) {
-	c.SameSite = http.SameSiteLaxMode
-	c.Secure = true
-
+func SetCookie(w http.ResponseWriter, r *http.Request, c *http.Cookie) error {
 	// Allow localhost to set cookies on http
 	for _, s := range [...]string{"127.0.0.1", "[::1]", "localhost"} {
 		// Compare as a prefix to avoid messing with :portnumber
 		if strings.HasPrefix(r.Host, s) {
 			c.Secure = false
-			break
+			c.SameSite = http.SameSiteDefaultMode
+			http.SetCookie(w, c)
+
+			return nil
 		}
 	}
+	c.Secure = true
+	c.SameSite = http.SameSiteNoneMode
 	http.SetCookie(w, c)
+
+	return nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -5,7 +5,6 @@ package util
 import (
 	"crypto/md5"
 	"encoding/base64"
-	"net/http"
 	"strings"
 	"unicode/utf8"
 )
@@ -168,24 +167,4 @@ func TrimString(s *string, maxLen int) {
 			*s = strings.ToValidUTF8(*s, "?")
 		}
 	}
-}
-
-// Adds security options to cookie and sets it in responsewriter
-func SetCookie(w http.ResponseWriter, r *http.Request, c *http.Cookie) error {
-	// Allow localhost to set cookies on http
-	for _, s := range [...]string{"127.0.0.1", "[::1]", "localhost"} {
-		// Compare as a prefix to avoid messing with :portnumber
-		if strings.HasPrefix(r.Host, s) {
-			c.Secure = false
-			c.SameSite = http.SameSiteDefaultMode
-			http.SetCookie(w, c)
-
-			return nil
-		}
-	}
-	c.Secure = true
-	c.SameSite = http.SameSiteNoneMode
-	http.SetCookie(w, c)
-
-	return nil
 }


### PR DESCRIPTION
8918ca67f144a017c7d758a53997dc49572b1886 did not revert the localhost-specific logic in the SetCookie helpers. With SameSite Strict or Lax, the Secure attribute is unnecessary and disallows HTTP-only deployment. The host detection is also incorrect. Behind a reverse proxy like nginx, the server will see requests originating from localhost, not the external domain.