### PR TITLE
Remove deploy-specific URLs in redirect handler

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -141,7 +141,7 @@ export default () => {
 			m.applyModeration(msg))
 
 	handlers[message.redirect] = (url: string) =>
-		location.href = url.replace(/shamik\.ooo|megu\.ca/, location.hostname) || url
+		location.href = url
 
 	handlers[message.notification] = (text: string) =>
 		new OverlayNotification(text)

--- a/client/client.ts
+++ b/client/client.ts
@@ -140,8 +140,12 @@ export default () => {
 		handle(msg.id, m =>
 			m.applyModeration(msg))
 
-	handlers[message.redirect] = (url: string) =>
-		location.href = url
+	handlers[message.redirect] = (msg: string) => {
+		const url = new URL(msg, location.origin)
+		if (/https?:/.test(url.protocol)) {
+			location.href = url.href
+		}
+	}
 
 	handlers[message.notification] = (text: string) =>
 		new OverlayNotification(text)


### PR DESCRIPTION
There is no need to explicitly rewrite the URL in the redirect handler because Window.location supports relative URLs.
e.g. location.href = "/a/catalog" will keep the origin hostname.

Also ensure the redirect URL is of an appropriate protocol.