### PR TITLE
moderation: fix ban page for global bans

### DIFF
--- a/db/bans_test.go
+++ b/db/bans_test.go
@@ -21,7 +21,7 @@ func TestBanUnban(t *testing.T) {
 	}
 
 	for _, board := range [...]string{"a", "all"} {
-		err = IsBanned(board, "::1")
+		_, err = IsBanned(board, "::1")
 		if err != common.ErrBanned {
 			UnexpectedError(t, err)
 		}

--- a/imager/upload.go
+++ b/imager/upload.go
@@ -125,7 +125,7 @@ func validateUploader(w http.ResponseWriter, r *http.Request) (err error) {
 	if err != nil {
 		return
 	}
-	err = db.IsBanned("all", ip)
+	_, err = db.IsBanned("all", ip)
 	if err != nil {
 		return
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -129,7 +129,7 @@ func assertNotBanned(w http.ResponseWriter, r *http.Request, board string,
 		httpError(w, r, common.StatusError{err, 400})
 		return false
 	}
-	err = db.IsBanned(board, ip)
+	isGlobal, err := db.IsBanned(board, ip)
 	switch err {
 	case nil:
 		return true
@@ -139,6 +139,9 @@ func assertNotBanned(w http.ResponseWriter, r *http.Request, board string,
 		return false
 	}
 
+	if isGlobal {
+		board = "all"
+	}
 	rec, err := db.GetBanInfo(ip, board)
 	switch err {
 	case nil:

--- a/websockets/post_creation.go
+++ b/websockets/post_creation.go
@@ -44,7 +44,7 @@ type ImageRequest struct {
 	Token, Name string
 }
 
-// CreateThread creates a new tread and writes it to the database.
+// CreateThread creates a new thread and writes it to the database.
 // open specifies, if the thread OP should stay open after creation.
 func CreateThread(req ThreadCreationRequest, ip string) (
 	post db.Post, err error,
@@ -53,7 +53,7 @@ func CreateThread(req ThreadCreationRequest, ip string) (
 		err = common.ErrInvalidBoard(req.Board)
 		return
 	}
-	err = db.IsBanned(req.Board, ip)
+	_, err = db.IsBanned(req.Board, ip)
 	if err != nil {
 		return
 	}
@@ -120,7 +120,7 @@ func CreatePost(
 ) (
 	post db.Post, msg []byte, err error,
 ) {
-	err = db.IsBanned(board, ip)
+	_, err = db.IsBanned(board, ip)
 	if err != nil {
 		return
 	}

--- a/websockets/synchronisation.go
+++ b/websockets/synchronisation.go
@@ -25,7 +25,7 @@ type reclaimRequest struct {
 	Password string
 }
 
-// Synchronise the client to a certain thread, assign it's ID and prepare to
+// Synchronise the client to a certain thread, assign its ID and prepare to
 // receive update messages.
 func (c *Client) synchronise(data []byte) error {
 	var msg syncRequest
@@ -45,7 +45,7 @@ func (c *Client) synchronise(data []byte) error {
 		}
 	}
 
-	err = db.IsBanned(msg.Board, c.ip)
+	_, err = db.IsBanned(msg.Board, c.ip)
 	if err != nil {
 		return err
 	}

--- a/websockets/websockets.go
+++ b/websockets/websockets.go
@@ -106,7 +106,7 @@ func Handler(w http.ResponseWriter, r *http.Request) (err error) {
 	}
 
 	// Prevents connection spam
-	err = db.IsBanned("all", ip)
+	_, err = db.IsBanned("all", ip)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Currently the ban page for global bans only shows when trying to view /all/ even though the poster is banned on all boards.