### PR TITLE
mod: remove captcha requirement to moderate

### DIFF
--- a/client/mod/panel.ts
+++ b/client/mod/panel.ts
@@ -103,12 +103,7 @@ export default class ModPanel extends View<null> {
 				if (checked.length) {
 					const args = HidableForm.forms["ban"].vals();
 					args["ids"] = mapToIDs(models);
-					if (config.captcha) {
-						trigger("renderCaptchaForm", () =>
-							this.postJSON("/api/ban", args));
-					} else {
-						this.postJSON("/api/ban", args);
-					}
+					this.postJSON("/api/ban", args);
 				}
 				break;
 			case "purgePost":

--- a/client/posts/menu.ts
+++ b/client/posts/menu.ts
@@ -91,7 +91,7 @@ class DeleteByIPForm extends MenuForm {
 		s += HTML`
 		<input type="text" name="reason" class="full-width" placeholder="${lang.ui["reason"]}">
 		<hr>`;
-		super(parent, parentID, s, { needCaptcha: true });
+		super(parent, parentID, s);
 		this.el.style.padding = "0.5em";
 
 		// Reason is required, if duration set

--- a/server/admin.go
+++ b/server/admin.go
@@ -377,10 +377,6 @@ func deletePostsByIP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Moderation rights are checked in plpgsql
-		err = assertSolvedCaptcha(w, r)
-		if err != nil {
-			return
-		}
 		creds, err := isLoggedIn(w, r)
 		if err != nil {
 			return
@@ -476,10 +472,6 @@ func ban(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		err = assertSolvedCaptcha(w, r)
-		if err != nil {
-			return
-		}
 		creds, err := isLoggedIn(w, r)
 		switch {
 		case err != nil:


### PR DESCRIPTION
I don't think board creation and deletion count as moderation, so they still need a captcha.